### PR TITLE
(fix) Proxy usage not working

### DIFF
--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -73,11 +73,11 @@ namespace Tbot
                 string host = (string)settings.General.Host ?? "localhost";
                 string port = (string)settings.General.Port ?? "8080";
                 string captchaKey = (string)settings.General.CaptchaAPIKey ?? "";
-                ProxySettings proxy = null;
-                if ((bool)settings.General.Proxy.Active && (string)settings.General.Proxy.Address != "")
+                ProxySettings proxy = new();
+                if ((bool)settings.General.Proxy.Enabled && (string)settings.General.Proxy.Address != "")
                 {
                     Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Initializing proxy");
-                    proxy.Enabled = (bool)settings.General.Proxy.Active;
+                    proxy.Enabled = (bool)settings.General.Proxy.Enabled;
                     proxy.Address = (string)settings.General.Proxy.Address;
                     proxy.Type = (string)settings.General.Proxy.Type ?? "socks5";
                     proxy.Username = (string)settings.General.Proxy.Username ?? "";

--- a/TBot/Services/OgamedService.cs
+++ b/TBot/Services/OgamedService.cs
@@ -37,7 +37,7 @@ namespace Tbot.Services
                 string args = "--universe=" + credentials.Universe + " --username=" + credentials.Username + " --password=" + credentials.Password + " --language=" + credentials.Language + " --auto-login=false --port=" + port + " --host=0.0.0.0 --api-new-hostname=http://" + host + ":" + port + " --cookies-filename=cookies.txt";
                 if (captchaKey != "")
                     args += " --nja-api-key=" + captchaKey;
-                if (proxySettings != null && proxySettings.Enabled)
+                if (proxySettings.Enabled)
                 {
                     args += " --proxy=" + proxySettings.Address;
                     args += " --proxy-type=" + proxySettings.Type;


### PR DESCRIPTION
Actually Proxy is not used even if it is set in settings.json. Here is the reason.

// Create ProxySettings object instead of null it. So check for null is no more needed.
ProxySettings proxy = new();

// Correct settings naming for Proxy.Enabled
settings.General.Proxy.Active renamed into settings.General.Proxy.Enabled
