### PR TITLE
Autofarm improvements

### DIFF
--- a/TBot/Includes/Helpers.cs
+++ b/TBot/Includes/Helpers.cs
@@ -2051,6 +2051,15 @@ namespace Tbot.Includes {
 			return output;
 		}
 
+		public static bool IsSettingSet(dynamic setting) {
+			try {
+				var x = setting;
+				return true;
+			} catch {
+				return false;
+			}
+		}
+
 		public static int CalcMaxPlanets(int astrophysics) {
 			return (int) Math.Round((float) ((astrophysics + 3) / 2), 0, MidpointRounding.ToZero);
 		}

--- a/TBot/Includes/Helpers.cs
+++ b/TBot/Includes/Helpers.cs
@@ -2011,7 +2011,7 @@ namespace Tbot.Includes {
 
 		public static Fleet GetFirstReturningEspionage(List<Fleet> fleets) {
 			var celestialEspionages = GetMissionsInProgress(Missions.Spy, fleets);
-			if (celestialEspionages != null) {
+			if (celestialEspionages.Count > 0) {
 				return celestialEspionages
 					.OrderBy(fleet => fleet.BackIn).First();
 			} else

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -1748,7 +1748,7 @@ namespace Tbot {
 												}
 											} else {
 												Helpers.WriteLog(LogType.Warning, LogSender.AutoFarm, $"Insufficient probes ({celestialProbes[closest.ID]}/{neededProbes}).");
-												if (settings.AutoFarm.BuildProbes == true) {
+												if (settings.AutoFarm.BuildProbes && settings.AutoFarm.BuildProbes == true) {
 													var buildProbes = neededProbes - celestialProbes[closest.ID];
 													var cost = Helpers.CalcPrice(Buildables.EspionageProbe, (int) buildProbes);
 													var tempCelestial = UpdatePlanet(closest, UpdateType.Resources);
@@ -1840,10 +1840,11 @@ namespace Tbot {
 							Celestial fromCelestial = null;
 							foreach (var c in closestCelestials) {
 								var tempCelestial = UpdatePlanet(c, UpdateType.Ships);
-								if (tempCelestial.Ships != null && tempCelestial.Ships.GetAmount(cargoShip) >= (numCargo + settings.AutoFarm.MinCargosToKeep) &&
-									Helpers.CalcDistance(tempCelestial.Coordinate, target.Celestial.Coordinate, serverData) < settings.AutoFarm.MaxFlightDistance) {
-										fromCelestial = tempCelestial;
-										break;
+								if (tempCelestial.Ships != null && tempCelestial.Ships.GetAmount(cargoShip) >= (numCargo + settings.AutoFarm.MinCargosToKeep)) {
+									var distance = Helpers.CalcDistance(tempCelestial.Coordinate, target.Celestial.Coordinate, serverData);
+									if (settings.AutoFarm.MaxFlightDistance && distance > settings.AutoFarm.MaxFlightDistance) continue;
+									fromCelestial = tempCelestial;
+									break;
 								}
 							}
 
@@ -1856,7 +1857,7 @@ namespace Tbot {
 									if (tempCelestial.Ships.GetAmount(cargoShip) < numCargo + (long) settings.AutoFarm.MinCargosToKeep
 										&& Helpers.CalcDistance(tempCelestial.Coordinate, target.Celestial.Coordinate, serverData) < settings.AutoFarm.MaxFlightDistance) {
 
-										if (settings.AutoFarm.BuildCargos == true) {
+										if (settings.AutoFarm.BuildCargos && settings.AutoFarm.BuildCargos == true) {
 											var neededCargos = numCargo + (long) settings.AutoFarm.MinCargosToKeep - tempCelestial.Ships.GetAmount(cargoShip);
 											var cost = Helpers.CalcPrice(cargoShip, (int) neededCargos);
 											if (tempCelestial.Resources.IsEnoughFor(cost))

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -1597,10 +1597,12 @@ namespace Tbot {
 
 									// Add each planet that has inactive status to farmTargets.
 									foreach (Celestial planet in scannedTargets) {
-										if (Helpers.IsSettingSet(settings.AutoFarm.MinimumPlayerRank) &&
-											settings.AutoFarm.MinimumPlayerRank != 0 && (int) settings.AutoFarm.MinimumPlayerRank < ((Planet) planet).Player.Rank) {
-											// Planer is below set minimum rank, skip.
-											continue;
+										// Check if target is below set minimum rank.
+										if (Helpers.IsSettingSet(settings.AutoFarm.MinimumPlayerRank) && settings.AutoFarm.MinimumPlayerRank != 0) {
+											if (planet.Coordinate.Type == Celestials.Planet && (int) settings.AutoFarm.MinimumPlayerRank < (planet as Planet).Player.Rank) {
+												// TODO: If Coordinate.Type == Moon, get corresponding planet and find Player.Rank to compare against.
+												continue;
+											}
 										}
 
 										if (Helpers.IsSettingSet(settings.AutoFarm.TargetsProbedBeforeAttack) &&

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -730,7 +730,7 @@ namespace Tbot {
 		private static void InitializeAutoFarm() {
 			Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Initializing autofarm...");
 			StopAutoFarm(false);
-			timers.Add("AutoFarmTimer", new Timer(AutoFarm, null, Helpers.CalcRandomInterval(IntervalType.AFewSeconds), Timeout.Infinite));
+			timers.Add("AutoFarmTimer", new Timer(AutoFarm, null, Helpers.CalcRandomInterval(IntervalType.AMinuteOrTwo), Timeout.Infinite));
 		}
 
 		private static void StopAutoFarm(bool echo = true) {
@@ -1748,6 +1748,24 @@ namespace Tbot {
 												}
 											} else {
 												Helpers.WriteLog(LogType.Warning, LogSender.AutoFarm, $"Insufficient probes ({celestialProbes[closest.ID]}/{neededProbes}).");
+												if (settings.AutoFarm.BuildProbes == true) {
+													var buildProbes = neededProbes - celestialProbes[closest.ID];
+													var cost = Helpers.CalcPrice(Buildables.EspionageProbe, (int) buildProbes);
+													var tempCelestial = UpdatePlanet(closest, UpdateType.Resources);
+													if (tempCelestial.Resources.IsEnoughFor(cost))
+														Helpers.WriteLog(LogType.Info, LogSender.AutoFarm, $"{tempCelestial.ToString()}: Building {buildProbes}x{Buildables.EspionageProbe.ToString()}");
+													else {
+														var buildableProbes = Helpers.CalcMaxBuildableNumber(Buildables.EspionageProbe, tempCelestial.Resources);
+														Helpers.WriteLog(LogType.Warning, LogSender.AutoFarm, $"{tempCelestial.ToString()}: Not enough resources to build {buildProbes}x{Buildables.EspionageProbe.ToString()}. {buildableProbes} will be built instead.");
+														buildProbes = buildableProbes;
+													}
+
+													var result = ogamedService.BuildShips(tempCelestial, Buildables.EspionageProbe, buildProbes);
+													if (result)
+														Helpers.WriteLog(LogType.Info, LogSender.AutoFarm, "Production succesfully started.");
+													else
+														Helpers.WriteLog(LogType.Warning, LogSender.AutoFarm, "Unable to start ship production.");
+												}
 												break;
 											}
 										}

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -1553,7 +1553,7 @@ namespace Tbot {
 							/// Galaxy scanning + target probing.
 							Helpers.WriteLog(LogType.Info, LogSender.AutoFarm, "Detecting farm targets...");
 							foreach (var range in settings.AutoFarm.ScanRange) {
-								if (settings.AutoFarm.TargetsProbedBeforeAttack && settings.AutoFarm.TargetsProbedBeforeAttack != 0 && numProbed >= settings.AutoFarm.TargetsProbedBeforeAttack) break;
+								if (Helpers.IsSettingSet(settings.AutoFarm.TargetsProbedBeforeAttack) && settings.AutoFarm.TargetsProbedBeforeAttack != 0 && numProbed >= (int) settings.AutoFarm.TargetsProbedBeforeAttack) break;
 
 								int galaxy		= (int) range.Galaxy;
 								int startSystem = (int) range.StartSystem;
@@ -1561,7 +1561,7 @@ namespace Tbot {
 
 								// Loop from start to end system.
 								for (var system = startSystem; system <= endSystem; system++) {
-									if (settings.AutoFarm.TargetsProbedBeforeAttack && settings.AutoFarm.TargetsProbedBeforeAttack != 0 && numProbed >= settings.AutoFarm.TargetsProbedBeforeAttack) break;
+									if (Helpers.IsSettingSet(settings.AutoFarm.TargetsProbedBeforeAttack) && settings.AutoFarm.TargetsProbedBeforeAttack != 0 && numProbed >= (int) settings.AutoFarm.TargetsProbedBeforeAttack) break;
 
 									// Check excluded system.
 									bool excludeSystem = false;
@@ -1597,7 +1597,14 @@ namespace Tbot {
 
 									// Add each planet that has inactive status to farmTargets.
 									foreach (Celestial planet in scannedTargets) {
-										if (settings.AutoFarm.TargetsProbedBeforeAttack && settings.AutoFarm.TargetsProbedBeforeAttack != 0 && numProbed >= settings.AutoFarm.TargetsProbedBeforeAttack) {
+										if (Helpers.IsSettingSet(settings.AutoFarm.MinimumPlayerRank) &&
+											settings.AutoFarm.MinimumPlayerRank != 0 && (int) settings.AutoFarm.MinimumPlayerRank < ((Planet) planet).Player.Rank) {
+											// Planer is below set minimum rank, skip.
+											continue;
+										}
+
+										if (Helpers.IsSettingSet(settings.AutoFarm.TargetsProbedBeforeAttack) &&
+											settings.AutoFarm.TargetsProbedBeforeAttack != 0 && numProbed >= (int) settings.AutoFarm.TargetsProbedBeforeAttack) {
 											Helpers.WriteLog(LogType.Info, LogSender.AutoFarm, "Maximum number of targets to probe reached, proceeding to attack.");
 											break;
 										}
@@ -1761,7 +1768,7 @@ namespace Tbot {
 												}
 											} else {
 												Helpers.WriteLog(LogType.Warning, LogSender.AutoFarm, $"Insufficient probes ({celestialProbes[closest.ID]}/{neededProbes}).");
-												if (settings.AutoFarm.BuildProbes && settings.AutoFarm.BuildProbes == true) {
+												if (Helpers.IsSettingSet(settings.AutoFarm.BuildProbes) && settings.AutoFarm.BuildProbes == true) {
 													var buildProbes = neededProbes - celestialProbes[closest.ID];
 													var cost = Helpers.CalcPrice(Buildables.EspionageProbe, (int) buildProbes);
 													var tempCelestial = UpdatePlanet(closest, UpdateType.Resources);
@@ -1853,7 +1860,7 @@ namespace Tbot {
 								var tempCelestial = UpdatePlanet(c, UpdateType.Ships);
 								if (tempCelestial.Ships != null && tempCelestial.Ships.GetAmount(cargoShip) >= (numCargo + settings.AutoFarm.MinCargosToKeep)) {
 									var distance = Helpers.CalcDistance(tempCelestial.Coordinate, target.Celestial.Coordinate, serverData);
-									if (settings.AutoFarm.MaxFlightDistance && distance > settings.AutoFarm.MaxFlightDistance) continue;
+									if (Helpers.IsSettingSet(settings.AutoFarm.MaxFlightDistance) && distance > settings.AutoFarm.MaxFlightDistance) continue;
 									fromCelestial = tempCelestial;
 									break;
 								}
@@ -1868,7 +1875,7 @@ namespace Tbot {
 									if (tempCelestial.Ships.GetAmount(cargoShip) < numCargo + (long) settings.AutoFarm.MinCargosToKeep
 										&& Helpers.CalcDistance(tempCelestial.Coordinate, target.Celestial.Coordinate, serverData) < settings.AutoFarm.MaxFlightDistance) {
 
-										if (settings.AutoFarm.BuildCargos && settings.AutoFarm.BuildCargos == true) {
+										if (Helpers.IsSettingSet(settings.AutoFarm.BuildCargos) && settings.AutoFarm.BuildCargos == true) {
 											var neededCargos = numCargo + (long) settings.AutoFarm.MinCargosToKeep - tempCelestial.Ships.GetAmount(cargoShip);
 											var cost = Helpers.CalcPrice(cargoShip, (int) neededCargos);
 											if (tempCelestial.Resources.IsEnoughFor(cost))

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -1907,13 +1907,13 @@ namespace Tbot {
 								tempCelestial = UpdatePlanet(tempCelestial, UpdateType.Ships);
 
 								// TODO Future: If prefered cargo ship is not available or not sufficient capacity, combine with other cargo type.
-								if (tempCelestial.Ships.GetAmount(cargoShip) < numCargo) {
-									if (tempCelestial.Ships.GetAmount(cargoShip) >= (long) settings.AutoFarm.MinCargosToSend) {
-										numCargo = Helpers.CalcShipNumberForPayload(loot, cargoShip, researches.HyperspaceTechnology, userInfo.Class, serverData.ProbeCargo);
-									} else {
-										Helpers.WriteLog(LogType.Info, LogSender.AutoFarm, $"Insufficient {cargoShip.ToString()} on {tempCelestial.Coordinate}, require {numCargo} {cargoShip.ToString()}.");
-										break;
+								if (tempCelestial.Ships.GetAmount(cargoShip) < numCargo + (long) settings.AutoFarm.MinCargosToKeep) {
+									var newNumCargo = tempCelestial.Ships.GetAmount(cargoShip) - (long) settings.AutoFarm.MinCargosToKeep;
+									if (newNumCargo < (long) settings.AutoFarm.MinCargosToSend) {
+										Helpers.WriteLog(LogType.Info, LogSender.AutoFarm, $"Insufficient {cargoShip.ToString()} on {tempCelestial.Coordinate}, require {numCargo + (long) settings.AutoFarm.MinCargosToKeep} {cargoShip.ToString()}.");
+										continue;
 									}
+									numCargo = newNumCargo;
 								}
 
 								slots = UpdateSlots();

--- a/TBot/settings.json
+++ b/TBot/settings.json
@@ -292,9 +292,12 @@
 				"Type": "Planet"
 			}
 		],
+		"MaxFlightDistance": 19000,
 		"CargoType": "LargeCargo",
 		"MinCargosToKeep": 0,
 		"MinCargosToSend": 2,
+		"BuildCargos": true,
+		"BuildProbes": true,
 		"MinimumResources": 100000,
 		"PreferedResource": "",
 		"SlotsToLeaveFree": 1,

--- a/TBot/settings.json
+++ b/TBot/settings.json
@@ -292,6 +292,7 @@
 				"Type": "Planet"
 			}
 		],
+		"TargetsProbedBeforeAttack": 30,
 		"MaxFlightDistance": 19000,
 		"CargoType": "LargeCargo",
 		"MinCargosToKeep": 0,


### PR DESCRIPTION
- Fixes:
   - Slightly improves time between probes by keeping records of variables locally, instead of making ogamed calls for each
   - Fixes sending attacks / probes from moons
   - Fixes exception thrown by GetFirstReturningEspionage
   - Reduce code: making use of existing helper functions
   - MinCargosToKeep setting implemented
- Additions:
   - MaxFlightDistance setting: avoids cargos flying vast distances if orgin near target has no cargos available
   - BuildCargos and BuildProbes setting: Build probes / cargos when not enough present on preferred / closest origin
   - TargetsProbedBeforeAttack setting: Skip further probing and proceed to attack after number of spy missions. Omit or use 0 to disable.