### PR TITLE
SleepMode & autofarm Fix

### DIFF
--- a/TBot/TBot.csproj
+++ b/TBot/TBot.csproj
@@ -58,7 +58,7 @@
 
   <ItemGroup>
     <None Update="settings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
- Change sendFleet succes check from "!=0" to ">0" (No impact as a valid fleetID is alway a positive value)

-  Added check in autoFarm Loops (spy loop and attack loop) to stop the execution if sleepMode is active (avoid autoFarm still working after sleepTime)

-  Added autoFarm check to exlude directly all targets with a bigger distance than already aborted fleet send (because return time would be in sleepMode) without trying to send fleet (no ogamed call)

- Added check to terminate autoFarm execution if at the spying phase a spy mission already return during sleepTime (as all plunder after that would also be in sleepTime hours)

-Added logs and coments



_This is only a working base, please review an improve if needed :)_