### PR TITLE
Solarsat Fixes

### DIFF
--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -2455,6 +2455,15 @@ namespace Tbot {
 					Resources xCostBuildable = Helpers.CalcPrice(buildable, level);
 					if (celestial is Moon) xCostBuildable.Deuterium += (long) autoMinerSettings.DeutToLeaveOnMoons;
 					
+					if (buildable == Buildables.SolarPlant || buildable == Buildables.FusionReactor) {
+						if (!celestial.Resources.IsEnoughFor(xCostBuildable) && celestial is Planet) {
+							Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Not enough resources for {buildable.ToString()}, building Solar Satellites instead.")
+							buildable = Buildables.SolarSatellite;
+							level = Helpers.GetNextLevel(celestial as Planet, buildable, userInfo.Class == CharacterClass.Collector, staff.Engineer, staff.IsFull);
+							xCostBuildable = Helpers.CalcPrice(buildable, level);
+						}
+					}
+
 					if (celestial.Resources.IsEnoughFor(xCostBuildable)) {
 						bool result = false;
 						if (buildable == Buildables.SolarSatellite) {
@@ -2462,7 +2471,8 @@ namespace Tbot {
 								Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Building {level.ToString()} x {buildable.ToString()} on {celestial.ToString()}");
 								result = ogamedService.BuildShips(celestial, buildable, level);
 							} else {
-								Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Skipping {celestial.ToString()}: There is already a production ongoing.");
+								Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Adding {level.ToString()} x {buildable.ToString()} to build queue on {celestial.ToString()}");
+								result = ogamedService.BuildShips(celestial, buildable, level);
 							}
 						} else {
 							Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Building {buildable.ToString()} level {level.ToString()} on {celestial.ToString()}");

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -2416,6 +2416,7 @@ namespace Tbot {
 			int level = 0;
 			bool started = false;
 			bool stop = false;
+			long energy = 0;
 			try {
 				Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Running AutoMine on {celestial.ToString()}");
 				celestial = UpdatePlanet(celestial, UpdateType.Fast);
@@ -2457,10 +2458,22 @@ namespace Tbot {
 					
 					if (buildable == Buildables.SolarPlant || buildable == Buildables.FusionReactor) {
 						if (!celestial.Resources.IsEnoughFor(xCostBuildable) && celestial is Planet) {
-							Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Not enough resources for {buildable.ToString()}, building Solar Satellites instead.")
+							Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Not enough resources for {buildable.ToString()}, building Solar Satellites instead.");
 							buildable = Buildables.SolarSatellite;
 							level = Helpers.GetNextLevel(celestial as Planet, buildable, userInfo.Class == CharacterClass.Collector, staff.Engineer, staff.IsFull);
 							xCostBuildable = Helpers.CalcPrice(buildable, level);
+						}
+					}
+
+					if (buildable == Buildables.Terraformer) {
+						if (!celestial.Resources.IsEnoughFor(xCostBuildable)) {
+							if (celestial.Resources.Energy < xCostBuildable.Energy) {
+								Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Not enough energy to build {buildable.ToString()}, building Solar Satellites to make up difference.");
+								energy = xCostBuildable.Energy - celestial.Resources.Energy;
+								buildable = Buildables.SolarSatellite;
+								level = Helpers.CalcNeededSolarSatellites(celestial as Planet, energy, userInfo.Class == CharacterClass.Collector, staff.Engineer, staff.IsFull);
+								xCostBuildable = Helpers.CalcPrice(buildable, level);
+							}
 						}
 					}
 

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -2481,7 +2481,7 @@ namespace Tbot {
 										started = true;
 										Helpers.WriteLog(LogType.Warning, LogSender.Brain, $"{level.ToString()}x {buildable.ToString()} succesfully built");
 									} else
-										Helpers.WriteLog(LogType.Warning, LogSender.Brain, $"Unable to start {level.ToString()}x {buildable.ToString()} construction: an unknow error has occurred");
+										Helpers.WriteLog(LogType.Warning, LogSender.Brain, $"Unable to start {level.ToString()}x {buildable.ToString()} construction: an unknown error has occurred");
 								}
 							} else {
 								celestial = UpdatePlanet(celestial, UpdateType.Constructions);


### PR DESCRIPTION
Changed Solar Satellite behavior, as most/many planets were running in the red and then development would stall unless enough resources were coming in from other planets.

Added Terraformer energy checking to build Solar Satellites to get enough energy to produce.