### PR TITLE
fix check Expeditions interval

### DIFF
--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -3730,12 +3730,13 @@ namespace Tbot {
 							.OrderBy(fleet => fleet.BackIn)
 							.ToList();
 					}
-
 					slots = UpdateSlots();
-					if (orderedFleets.Count == 0 || slots.ExpFree > 0) {
+					if (orderedFleets.Count == 0 || ((bool) settings.Expeditions.WaitForMajorityOfExpeditions && slots.ExpFree > (slots.ExpTotal / 2))) {
 						interval = Helpers.CalcRandomInterval(IntervalType.AboutFiveMinutes);
 					} else {
 						interval = (int) ((1000 * orderedFleets.First().BackIn) + Helpers.CalcRandomInterval(IntervalType.AMinuteOrTwo));
+						if (orderedFleets.Count >= 6)
+							interval += Helpers.CalcRandomInterval(IntervalType.AMinuteOrTwo);
 					}
 					time = GetDateTime();
 					if (interval <= 0)


### PR DESCRIPTION
Fix a 5 minute loop when TBot checks for expeditions that started before he logging in.

Increase the interval before next check if there are many expeditions slots.