### PR TITLE
fix check Expeditions interval

### DIFF
--- a/TBot/Includes/Helpers.cs
+++ b/TBot/Includes/Helpers.cs
@@ -1490,7 +1490,7 @@ namespace Tbot.Includes {
 		public static Buildables GetNextEnergySourceToBuild(Planet planet, int maxSolarPlant, int maxFusionReactor) {
 			if (planet.Buildings.SolarPlant < maxSolarPlant)
 				return Buildables.SolarPlant;
-			if (planet.Buildings.FusionReactor < maxFusionReactor)
+			if (planet.Buildings.DeuteriumSynthesizer >= 5 && planet.Buildings.FusionReactor < maxFusionReactor)
 				return Buildables.FusionReactor;
 			return Buildables.SolarSatellite;
 		}

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -1524,6 +1524,7 @@ namespace Tbot {
 								)
 							)) as Planet;
 					} else {
+						Helpers.WriteLog(LogType.Warning, LogSender.Brain, "Unable to parse Brain.AutoResearch.Target. Falling back to planet with biggest Research Lab");
 						celestials = UpdatePlanets(UpdateType.Facilities);
 						celestial = celestials
 							.Where(c => c.Coordinate.Type == Celestials.Planet)
@@ -1586,6 +1587,7 @@ namespace Tbot {
 					else {
 						research = Helpers.GetNextResearchToBuild(celestial as Planet, researches, (bool) settings.Brain.AutoMine.PrioritizeRobotsAndNanitesOnNewPlanets, slots, (int) settings.Brain.AutoResearch.MaxEnergyTechnology, (int) settings.Brain.AutoResearch.MaxLaserTechnology, (int) settings.Brain.AutoResearch.MaxIonTechnology, (int) settings.Brain.AutoResearch.MaxHyperspaceTechnology, (int) settings.Brain.AutoResearch.MaxPlasmaTechnology, (int) settings.Brain.AutoResearch.MaxCombustionDrive, (int) settings.Brain.AutoResearch.MaxImpulseDrive, (int) settings.Brain.AutoResearch.MaxHyperspaceDrive, (int) settings.Brain.AutoResearch.MaxEspionageTechnology, (int) settings.Brain.AutoResearch.MaxComputerTechnology, (int) settings.Brain.AutoResearch.MaxAstrophysics, (int) settings.Brain.AutoResearch.MaxIntergalacticResearchNetwork, (int) settings.Brain.AutoResearch.MaxWeaponsTechnology, (int) settings.Brain.AutoResearch.MaxShieldingTechnology, (int) settings.Brain.AutoResearch.MaxArmourTechnology, (bool) settings.Brain.AutoResearch.OptimizeForStart, (bool) settings.Brain.AutoResearch.EnsureExpoSlots);
 					}
+					/*
 					if (
 						research != Buildables.Null &&
 						research != Buildables.IntergalacticResearchNetwork &&
@@ -1602,6 +1604,7 @@ namespace Tbot {
 							research = Buildables.IntergalacticResearchNetwork;
 						}
 					}
+					*/
 
 					int level = Helpers.GetNextLevel(researches, research);
 					if (research != Buildables.Null) {

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -3756,12 +3756,13 @@ namespace Tbot {
 							.OrderBy(fleet => fleet.BackIn)
 							.ToList();
 					}
-
 					slots = UpdateSlots();
-					if (orderedFleets.Count == 0 || slots.ExpFree > 0) {
+					if (orderedFleets.Count == 0 || ((bool) settings.Expeditions.WaitForMajorityOfExpeditions && slots.ExpFree > (slots.ExpTotal / 2))) {
 						interval = Helpers.CalcRandomInterval(IntervalType.AboutFiveMinutes);
 					} else {
 						interval = (int) ((1000 * orderedFleets.First().BackIn) + Helpers.CalcRandomInterval(IntervalType.AMinuteOrTwo));
+						if (orderedFleets.Count >= (long) settings.Expeditions.NumberSlotsToIncreaseIntervalCheck)
+							interval += Helpers.CalcRandomInterval(IntervalType.AMinuteOrTwo);
 					}
 					time = GetDateTime();
 					if (interval <= 0)

--- a/TBot/TBot.csproj
+++ b/TBot/TBot.csproj
@@ -5,15 +5,15 @@
     <TargetFramework>net5.0</TargetFramework>
     <Nullable>disable</Nullable>
     <Authors>ELK-Lab</Authors>
-    <Version>0.2.55</Version>
+    <Version>0.2.56</Version>
     <StartupObject>Tbot.Program</StartupObject>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <Copyright>2021 © ELK-Lab</Copyright>
     <PackageLicenseExpression>https://licenses.nuget.org/MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://www.ogame-tbot.net</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ogame-tbot/TBot</RepositoryUrl>
-    <AssemblyVersion>0.2.55.0</AssemblyVersion>
-    <FileVersion>0.2.55.0</FileVersion>
+    <AssemblyVersion>0.2.56.0</AssemblyVersion>
+    <FileVersion>0.2.56.0</FileVersion>
     <Description>OGame Bot</Description>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>ELK-Lab.pfx</AssemblyOriginatorKeyFile>

--- a/TBot/settings.json
+++ b/TBot/settings.json
@@ -245,6 +245,7 @@
 		},
 		"WaitForAllExpeditions": false,
 		"WaitForMajorityOfExpeditions": true,
+		"NumberSlotsToIncreaseIntervalCheck": 8,
 		"SplitExpeditionsBetweenSystems": {
 			"Active": false,
 			"Range": 1


### PR DESCRIPTION
Fix a 5 minute loop when TBot checks for expeditions that started before he logging in.

> i don't like that, i'd rather make that dynamically calculated. at the beginning 6 is not a low value

It's possible to define a limit of slots, which once exceeded will increase the time interval before resending shipments 