### PR TITLE
Use PhysicalFileProvider instead of FileSystemWatcher

### DIFF
--- a/TBot/TBot.csproj
+++ b/TBot/TBot.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />


### PR DESCRIPTION
Fix addressing #63.

Tested on Windows 11, needs testing for other systems.