### PR TITLE
Fix and improve AutoFleetSave and GetFleetSaveDestination

### DIFF
--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -951,12 +951,12 @@ namespace Tbot {
 				}
 			}
 
-			Missions mission = Missions.Harvest;
+			Missions mission = Missions.Deploy;
 			List<FleetHypotesis> fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
 
 			if (fleetHypotesis.Count() == 0) {
-				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.ToString()} no Harvest possible doing Deploy..");
-				mission = Missions.Deploy;
+				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.ToString()} no Deploy possible doing Harvest..");
+				mission = Missions.Harvest;
 				fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
 
 				if (fleetHypotesis.Count() == 0 && !forceUnsafe ) {


### PR DESCRIPTION
Fix: 
removed loop which caused to parsed 15 times the same SS (GalaxyInfo already contains all planets info

Improve: 
Transformed FleetHypotesis to List<FleetHypotesis>, allowing to parse 10 SS for debris field, adding existing field into the filed, checking for the validity of each one of them via CheckFuel func, and attempting to send it until sent is succesfull (in case of not existing debris anymore, sent to next debris destination).

Next step:
Improving destination on ForceUnsafe parameter --> going to 1,1,1 is just not possible (fuel cost, time etc, see comment in the code below)