### PR TITLE
Tbot more telegram features added

### DIFF
--- a/TBot/Includes/TelegramMessenger.cs
+++ b/TBot/Includes/TelegramMessenger.cs
@@ -41,6 +41,8 @@ namespace Tbot.Includes {
 			{
 				"/ghostsleep",
 				"/ghost",
+				"/ghostto",
+				"/switch",
 				"/sleep",
 				"/wakeup",
 				"/collect",
@@ -50,7 +52,10 @@ namespace Tbot.Includes {
 				"/ping",
 				"/stopautomine",
 				"/startautomine",
+				"/getinfo",
+				"/celestial",
 				"/recall",
+				"/editsettings",
 				"/help"
 			};
 
@@ -62,7 +67,11 @@ namespace Tbot.Includes {
 					try {
 						Tbot.Program.WaitFeature();
 
-						if (message.Text.ToLower().Contains("/ghost")) {
+						if (message.Text.ToLower().Split(' ')[0] == "/ghost") {
+							if (message.Text.Split(' ').Length != 2) {
+								await botClient.SendTextMessageAsync(message.Chat, "Need mission value!");
+								return;
+							}
 							var arg = message.Text.Split(' ')[1];
 							long duration = Int32.Parse(arg) * 60 * 60; //second
 
@@ -77,7 +86,53 @@ namespace Tbot.Includes {
 							return;
 
 						}
-						else if (message.Text.ToLower().Contains("/ghostsleep")) {
+						else if (message.Text.ToLower().Split(' ')[0] == "/ghostto") {
+							if (message.Text.Split(' ').Length != 3) {
+								await botClient.SendTextMessageAsync(message.Chat, "Need mission value!");
+								return;
+							}
+							var arg = message.Text.Split(' ')[1];
+							var test = message.Text.Split(' ')[2];
+							test = char.ToUpper(test[0]) + test.Substring(1);
+							Missions mission;
+
+							if (!Missions.TryParse(test, out mission)) {
+								await botClient.SendTextMessageAsync(message.Chat, $"{test} error: Value must be 'Harvest','Deploy','Transport','Spy','Colonize'");
+								return;
+							}
+							long duration = Int32.Parse(arg) * 60 * 60; //second
+
+							var celestialsToFleetsave = Tbot.Program.UpdateCelestials();
+							celestialsToFleetsave = celestialsToFleetsave.Where(c => c.Coordinate.Type == Celestials.Moon).ToList();
+							if (celestialsToFleetsave.Count() == 0)
+								celestialsToFleetsave = celestialsToFleetsave.Where(c => c.Coordinate.Type == Celestials.Planet).ToList();
+
+							foreach (Celestial celestial in celestialsToFleetsave)
+								Tbot.Program.AutoFleetSave(celestial, false, duration, false, false, mission);
+
+							return;
+
+						}
+						else if (message.Text.ToLower().Split(' ')[0] == "/switch") {
+							if (message.Text.Split(' ').Length != 2) {
+								await botClient.SendTextMessageAsync(message.Chat, "Need speed value (eg: 5 for 50%)");
+								return;
+							}
+							var test = message.Text.Split(' ')[1];
+							decimal speed = decimal.Parse(test);
+
+							if (1 <= speed && speed <= 10) {
+								Tbot.Program.TelegramSwitch(speed);
+								return;
+							}
+							await botClient.SendTextMessageAsync(message.Chat, $"{test} error: Value must be 1 or 2 or 3 for 10%,20%,30% etc.");
+							return;
+						}
+						else if (message.Text.ToLower().Split(' ')[0] == "/ghostsleep") {
+							if (message.Text.Split(' ').Length != 2) {
+								await botClient.SendTextMessageAsync(message.Chat, "Need mission value!");
+								return;
+							}
 							var arg = message.Text.Split(' ')[1];
 							long duration = Int32.Parse(arg) * 60 * 60; //second
 
@@ -92,14 +147,22 @@ namespace Tbot.Includes {
 							IsSomeStoppedFeatures = true;
 							return;
 						}
-						else if (message.Text.ToLower().Contains("/recall")) {
+						else if (message.Text.ToLower().Split(' ')[0] == ("/recall")) {
+							if (message.Text.Split(' ').Length != 2) {
+								await botClient.SendTextMessageAsync(message.Chat, "Need mission value!");
+								return;
+							}
 							var arg = message.Text.Split(' ')[1];
 							int fleetId = Int32.Parse(arg);
 
 							Tbot.Program.TelegramRetireFleet(fleetId);
 							return;
 						}
-						else if (message.Text.ToLower().Contains("/sleep")) {
+						else if (message.Text.ToLower().Split(' ')[0] == "/sleep") {
+							if (message.Text.Split(' ').Length != 2) {
+								await botClient.SendTextMessageAsync(message.Chat, "Need mission value!");
+								return;
+							}
 							var arg = message.Text.Split(' ')[1];
 							int sleepingtime = Int32.Parse(arg);
 
@@ -110,69 +173,171 @@ namespace Tbot.Includes {
 							return;
 
 						}
-						else if (message.Text.ToLower().Contains("/wakeup")) {
+						else if (message.Text.ToLower().Split(' ')[0] == "/wakeup") {
+							if (message.Text.Split(' ').Length != 1) {
+								await botClient.SendTextMessageAsync(message.Chat, "No value needed!");
+								return;
+							}
 							Tbot.Program.WakeUpNow(null);
 							return;
 
 						}
-						else if (message.Text.ToLower().Contains("/send")) {
-							//var msg = message.Text.Split(' ')[1];
+						else if (message.Text.ToLower().Split(' ')[0] == "/send") {
+							if (message.Text.Split(' ').Length < 2) {
+								await botClient.SendTextMessageAsync(message.Chat, "Need message value!");
+								return;
+							}
 							var msg = message.Text.Split(new[] { ' ' }, 2).Last();
 							Tbot.Program.TelegramMesgAttacker(msg);
 							return;
 
 						}
-						else if (message.Text.ToLower().Contains("/stopexpe")) {
+						else if (message.Text.ToLower().Split(' ')[0] == "/stopexpe") {
+							if (message.Text.Split(' ').Length != 1) {
+								await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+								return;
+							}
 
 							Tbot.Program.StopExpeditions();
 							await botClient.SendTextMessageAsync(message.Chat, "Expedition stopped!");
 							return;
 
 						}
-						else if (message.Text.ToLower().Contains("/startexpe")) {
+						else if (message.Text.ToLower().Split(' ')[0] == "/startexpe") {
+							if (message.Text.Split(' ').Length != 1) {
+								await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+								return;
+							}
 
 							Tbot.Program.InitializeExpeditions();
 							await botClient.SendTextMessageAsync(message.Chat, "Expedition initialized!");
 
 						}
-						else if (message.Text.ToLower().Contains("/collect")) {
+						else if (message.Text.ToLower().Split(' ')[0] == "/collect") {
+							if (message.Text.Split(' ').Length != 1) {
+								await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+								return;
+							}
 
 							Tbot.Program.InitializeBrainRepatriate();
 							Tbot.Program.AutoRepatriate(null);
 							Tbot.Program.StopBrainRepatriate();
 							return;
 						}
-						else if (message.Text.ToLower().Contains("/stopautomine")) {
+						else if (message.Text.ToLower().Split(' ')[0] == "/stopautomine") {
+							if (message.Text.Split(' ').Length != 1) {
+								await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+								return;
+							}
 
 							Tbot.Program.StopBrainAutoMine();
 							await botClient.SendTextMessageAsync(message.Chat, "AutoMine stopped!");
 							return;
 						}
-						else if (message.Text.ToLower().Contains("/startautomine")) {
+						else if (message.Text.ToLower().Split(' ')[0] == "/startautomine") {
+							if (message.Text.Split(' ').Length != 1) {
+								await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+								return;
+							}
 
 							Tbot.Program.InitializeBrainAutoMine();
 							await botClient.SendTextMessageAsync(message.Chat, "AutoMine Started!");
 							return;
 						}
-						else if (message.Text.ToLower().Contains("/ping")) {
+						else if (message.Text.ToLower().Split(' ')[0] == "/getinfo") {
+							if (message.Text.Split(' ').Length != 1) {
+								await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+								return;
+							}
+
+							Tbot.Program.TelegramGetInfo();
+							return;
+						} else if (message.Text.ToLower().Split(' ')[0] == "/celestial") {
+							if (message.Text.Split(' ').Length != 3) {
+								await botClient.SendTextMessageAsync(message.Chat, "Need coordinate and type! (/celestial 2:56:8 moon/planet)");
+								return;
+							}
+
+							Coordinate coord = new();
+							string type = message.Text.ToLower().Split(' ')[2];
+							if ( (!type.Equals("moon")) && (!type.Equals("planet")) ) {
+								await botClient.SendTextMessageAsync(message.Chat, $"Need value moon or planet (got {type})");
+								return;
+							}
+
+							try {
+								coord.Galaxy = Int32.Parse(message.Text.Split(' ')[1].Split(':')[0]);
+								coord.System = Int32.Parse(message.Text.Split(' ')[1].Split(':')[1]);
+								coord.Position = Int32.Parse(message.Text.Split(' ')[1].Split(':')[2]);
+							} catch {
+								await botClient.SendTextMessageAsync(message.Chat, "Error while parsing coordinate! (must be like 3:125:9)");
+								return;
+							}
+
+							type = char.ToUpper(type[0]) + type.Substring(1);
+							Tbot.Program.TelegramCelestial(coord, type);
+							return;
+
+						} else if (message.Text.ToLower().Split(' ')[0] == "/editsettings") {
+							if (message.Text.Split(' ').Length != 3) {
+								await botClient.SendTextMessageAsync(message.Chat, "Need coordinate and type! (/editsettings 2:56:8 moon/planet)");
+								return;
+							}
+
+							Coordinate coord = new();
+							string type = message.Text.ToLower().Split(' ')[2];
+							if ((!type.Equals("moon")) && (!type.Equals("planet"))) {
+								await botClient.SendTextMessageAsync(message.Chat, $"Need value moon or planet (got {type})");
+								return;
+							}
+
+							try {
+								coord.Galaxy = Int32.Parse(message.Text.Split(' ')[1].Split(':')[0]);
+								coord.System = Int32.Parse(message.Text.Split(' ')[1].Split(':')[1]);
+								coord.Position = Int32.Parse(message.Text.Split(' ')[1].Split(':')[2]);
+							} catch {
+								await botClient.SendTextMessageAsync(message.Chat, "Error while parsing coordinate! (must be like 3:125:9)");
+								return;
+							}
+
+							type = char.ToUpper(type[0]) + type.Substring(1);
+							Tbot.Program.TelegramCelestial(coord, type, true);
+							return;
+
+						}
+						else if (message.Text.ToLower().Split(' ')[0] == "/ping") {
+							if (message.Text.Split(' ').Length != 1) {
+								await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+								return;
+							}
 							await botClient.SendTextMessageAsync(message.Chat, "pong");
 							return;
 
 						}
-						else if (message.Text.ToLower().Contains("/help")) {
+						else if (message.Text.ToLower().Split(' ')[0] == "/help") {
+							if (message.Text.Split(' ').Length != 1) {
+								await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+								return;
+							}
 							await botClient.SendTextMessageAsync(message.Chat,
 								"/ghostsleep - '/ghostsleep 5' -> Wait for fleets to return, ghost and sleep for 5hours\n" +
 								"/ghost - '/ghost 4' -> Ghost fleet for 4 hours\n" +
+								"/ghostto - '/ghostto 4 Harvest'\n" +
 								"/sleep - '/sleep 1' -> Stop bot, inactive for 1 hours\n" +
 								"/recall - '/recall 65656' -> recall fleet id 65656\n" +
 								"/wakeup - Wakeup bot\n" +
-								"/send - '/send hello' -> Send 'hello' to current attacker\n" +
+								"/send - '/send hello dude' -> Send 'hello dude' to current attacker\n" +
 								"/stopexpe - Stop sending expedition\n" +
 								"/startexpe - Start sending expedition\n" +
 								"/collect - Collect planets resources to current moon\n" +
 								"/stopautomine - stop brain automine\n" +
 								"/startautomine - start brain automine\n" +
-								"/ping - Ping bot"
+								"/celestial - '/celestial 2:45:8 Moon' (Moon/Planet) Update program current celestial target\n" +
+								"/getinfo - Get current celestial resources and ships\n" +
+								"/switch - '/switch 5' -> switch current celestial resources and fleets to its planet or moon at 50% speed\n" +
+								"/editsettings - '/editsettings 2:425:9 moon -> Edit JSON file to change: Expedition, Transport, Repatriate and AutoReseach (Origin/Target) celestial\n" + 
+								"/ping - Ping bot\n" +
+								"/help - Display this help"
 							);
 							return;
 
@@ -209,22 +374,7 @@ namespace Tbot.Includes {
 				AllowedUpdates = Array.Empty<UpdateType>(),
 				ThrowPendingUpdates = true
 			};
-
-			await Client.SendTextMessageAsync(Channel,
-				"/ghostsleep - '/ghostsleep 5' -> Wait for fleets to return, ghost and sleep for 5hours\n\n" +
-				"/ghost - '/ghost 4' -> Ghost fleet for 4 hours\n\n" +
-				"/sleep - '/sleep 1' -> Stop bot, inactive for 1 hours\n\n" +
-				"/recall - '/recall 65656' -> recall fleet id 65656\n\n" +
-				"/wakeup - Wakeup bot\n\n" +
-				"/send - '/send hello' -> Send 'hello' to current attacker\n\n" +
-				"/stopexpe - Stop sending expedition\n\n" +
-				"/startexpe - Start sending expedition\n\n" +
-				"/collect - Collect planets resources to current moon\n\n" +
-				"/stopautomine - stop brain automine\n\n" +
-				"/startautomine - start brain automine\n\n" +
-				"/ping - Ping bot"
-			);
-
+			
 			await Client.ReceiveAsync(HandleUpdateAsync, HandleErrorAsync, receiverOptions, cts.Token);
 		}
 	}

--- a/TBot/Includes/TelegramMessenger.cs
+++ b/TBot/Includes/TelegramMessenger.cs
@@ -1,20 +1,30 @@
 using Tbot.Model;
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Text;
 using Telegram.Bot;
+using Telegram.Bot.Polling;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Exceptions;
+using System.Linq;
+
 
 namespace Tbot.Includes {
+
 	class TelegramMessenger {
 		public string Api { get; private set; }
 		public string Channel { get; private set; }
-		private TelegramBotClient Client { get; set; }
+		static ITelegramBotClient Client { get; set; }
 		public TelegramMessenger(string api, string channel) {
 			Api = api;
 			Client = new TelegramBotClient(Api);
 			Channel = channel;
 		}
-
+		
+		
 		public async void SendMessage(string message) {
 			Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Sending Telegram message...");
 			try {
@@ -22,6 +32,200 @@ namespace Tbot.Includes {
 			} catch (Exception e) {
 				Helpers.WriteLog(LogType.Error, LogSender.Tbot, $"Could not send Telegram message: an exception has occurred: {e.Message}");
 			}
+		}
+
+		public async Task HandleUpdateAsync(ITelegramBotClient botClient, Update update, CancellationToken cancellationToken) {
+			bool IsSomeStoppedFeatures = false;
+
+			List<string> commands = new List<string>()
+			{
+				"/ghostsleep",
+				"/ghost",
+				"/sleep",
+				"/wakeup",
+				"/collect",
+				"stopexpe",
+				"startexpe",
+				"/send",
+				"/ping",
+				"/stopautomine",
+				"/startautomine",
+				"/recall",
+				"/help"
+			};
+
+			if (update.Type == UpdateType.Message) {
+				var message = update.Message;
+
+				if (commands.Any(x => message.Text.ToLower().Contains(x))) {
+
+					try {
+						Tbot.Program.WaitFeature();
+
+						if (message.Text.ToLower().Contains("/ghost")) {
+							var arg = message.Text.Split(' ')[1];
+							long duration = Int32.Parse(arg) * 60 * 60; //second
+
+							var celestialsToFleetsave = Tbot.Program.UpdateCelestials();
+							celestialsToFleetsave = celestialsToFleetsave.Where(c => c.Coordinate.Type == Celestials.Moon).ToList();
+							if (celestialsToFleetsave.Count() == 0)
+								celestialsToFleetsave = celestialsToFleetsave.Where(c => c.Coordinate.Type == Celestials.Planet).ToList();
+
+							foreach (Celestial celestial in celestialsToFleetsave)
+								Tbot.Program.AutoFleetSave(celestial, false, duration, false, false);
+								
+							return;
+
+						}
+						else if (message.Text.ToLower().Contains("/ghostsleep")) {
+							var arg = message.Text.Split(' ')[1];
+							long duration = Int32.Parse(arg) * 60 * 60; //second
+
+							var celestialsToFleetsave = Tbot.Program.UpdateCelestials();
+							celestialsToFleetsave = celestialsToFleetsave.Where(c => c.Coordinate.Type == Celestials.Moon).ToList();
+							if (celestialsToFleetsave.Count() == 0)
+								celestialsToFleetsave = celestialsToFleetsave.Where(c => c.Coordinate.Type == Celestials.Planet).ToList();
+
+							foreach (Celestial celestial in celestialsToFleetsave)
+								Tbot.Program.AutoFleetSave(celestial, false, duration, false, true);
+
+							IsSomeStoppedFeatures = true;
+							return;
+						}
+						else if (message.Text.ToLower().Contains("/recall")) {
+							var arg = message.Text.Split(' ')[1];
+							int fleetId = Int32.Parse(arg);
+
+							Tbot.Program.TelegramRetireFleet(fleetId);
+							return;
+						}
+						else if (message.Text.ToLower().Contains("/sleep")) {
+							var arg = message.Text.Split(' ')[1];
+							int sleepingtime = Int32.Parse(arg);
+
+							DateTime timeNow = Tbot.Program.GetDateTime();
+							DateTime WakeUpTime = timeNow.AddHours(sleepingtime);
+	
+							Tbot.Program.SleepNow(WakeUpTime);
+							return;
+
+						}
+						else if (message.Text.ToLower().Contains("/wakeup")) {
+							Tbot.Program.WakeUpNow(null);
+							return;
+
+						}
+						else if (message.Text.ToLower().Contains("/send")) {
+							//var msg = message.Text.Split(' ')[1];
+							var msg = message.Text.Split(new[] { ' ' }, 2).Last();
+							Tbot.Program.TelegramMesgAttacker(msg);
+							return;
+
+						}
+						else if (message.Text.ToLower().Contains("/stopexpe")) {
+
+							Tbot.Program.StopExpeditions();
+							await botClient.SendTextMessageAsync(message.Chat, "Expedition stopped!");
+							return;
+
+						}
+						else if (message.Text.ToLower().Contains("/startexpe")) {
+
+							Tbot.Program.InitializeExpeditions();
+							await botClient.SendTextMessageAsync(message.Chat, "Expedition initialized!");
+
+						}
+						else if (message.Text.ToLower().Contains("/collect")) {
+
+							Tbot.Program.InitializeBrainRepatriate();
+							Tbot.Program.AutoRepatriate(null);
+							Tbot.Program.StopBrainRepatriate();
+							return;
+						}
+						else if (message.Text.ToLower().Contains("/stopautomine")) {
+
+							Tbot.Program.StopBrainAutoMine();
+							await botClient.SendTextMessageAsync(message.Chat, "AutoMine stopped!");
+							return;
+						}
+						else if (message.Text.ToLower().Contains("/startautomine")) {
+
+							Tbot.Program.InitializeBrainAutoMine();
+							await botClient.SendTextMessageAsync(message.Chat, "AutoMine Started!");
+							return;
+						}
+						else if (message.Text.ToLower().Contains("/ping")) {
+							await botClient.SendTextMessageAsync(message.Chat, "pong");
+							return;
+
+						}
+						else if (message.Text.ToLower().Contains("/help")) {
+							await botClient.SendTextMessageAsync(message.Chat,
+								"/ghostsleep - '/ghostsleep 5' -> Wait for fleets to return, ghost and sleep for 5hours\n" +
+								"/ghost - '/ghost 4' -> Ghost fleet for 4 hours\n" +
+								"/sleep - '/sleep 1' -> Stop bot, inactive for 1 hours\n" +
+								"/recall - '/recall 65656' -> recall fleet id 65656\n" +
+								"/wakeup - Wakeup bot\n" +
+								"/send - '/send hello' -> Send 'hello' to current attacker\n" +
+								"/stopexpe - Stop sending expedition\n" +
+								"/startexpe - Start sending expedition\n" +
+								"/collect - Collect planets resources to current moon\n" +
+								"/stopautomine - stop brain automine\n" +
+								"/startautomine - start brain automine\n" +
+								"/ping - Ping bot"
+							);
+							return;
+
+						}
+					} catch (NullReferenceException ex) {
+						throw ex;
+
+					} finally {
+						if (!IsSomeStoppedFeatures)
+							Tbot.Program.releaseFeature();
+						else {
+							Tbot.Program.releaseNotStoppedFeature();
+						}
+
+
+					}
+				}
+			}
+		}
+
+
+		async Task HandleErrorAsync(ITelegramBotClient botClient, Exception exception, CancellationToken cancellationToken) {
+			if (exception is ApiRequestException apiRequestException) {
+				await botClient.SendTextMessageAsync(Channel, apiRequestException.ToString());
+			}
+		}
+
+		public async void TelegramBot() {
+			
+			var cts = new CancellationTokenSource();
+			var cancellationToken = cts.Token;
+
+			var receiverOptions = new ReceiverOptions {
+				AllowedUpdates = Array.Empty<UpdateType>(),
+				ThrowPendingUpdates = true
+			};
+
+			await Client.SendTextMessageAsync(Channel,
+				"/ghostsleep - '/ghostsleep 5' -> Wait for fleets to return, ghost and sleep for 5hours\n\n" +
+				"/ghost - '/ghost 4' -> Ghost fleet for 4 hours\n\n" +
+				"/sleep - '/sleep 1' -> Stop bot, inactive for 1 hours\n\n" +
+				"/recall - '/recall 65656' -> recall fleet id 65656\n\n" +
+				"/wakeup - Wakeup bot\n\n" +
+				"/send - '/send hello' -> Send 'hello' to current attacker\n\n" +
+				"/stopexpe - Stop sending expedition\n\n" +
+				"/startexpe - Start sending expedition\n\n" +
+				"/collect - Collect planets resources to current moon\n\n" +
+				"/stopautomine - stop brain automine\n\n" +
+				"/startautomine - start brain automine\n\n" +
+				"/ping - Ping bot"
+			);
+
+			await Client.ReceiveAsync(HandleUpdateAsync, HandleErrorAsync, receiverOptions, cts.Token);
 		}
 	}
 }

--- a/TBot/Model/Enums.cs
+++ b/TBot/Model/Enums.cs
@@ -94,6 +94,7 @@ namespace Tbot.Model {
 	}
 
 	public enum Missions {
+		None = 0,
 		Attack = 1,
 		FederalAttack = 2,
 		Transport = 3,

--- a/TBot/Model/Enums.cs
+++ b/TBot/Model/Enums.cs
@@ -200,7 +200,7 @@ namespace Tbot.Model {
 		AboutAnHour
 	}
 
-	public enum UpdateType {
+	public enum UpdateTypes {
 		Fast,
 		Techs,
 		Full,

--- a/TBot/Model/Types.cs
+++ b/TBot/Model/Types.cs
@@ -271,16 +271,18 @@ namespace Tbot.Model {
 	}
 
 	public class Resources {
-		public Resources(long metal = 0, long crystal = 0, long deuterium = 0, long energy = 0, long darkmatter = 0) {
+		public Resources(long metal = 0, long crystal = 0, long deuterium = 0, long food = 0, long energy = 0, long darkmatter = 0) {
 			Metal = metal;
 			Crystal = crystal;
 			Deuterium = deuterium;
+			Food = food;
 			Energy = energy;
 			Darkmatter = darkmatter;
 		}
 		public long Metal { get; set; }
 		public long Crystal { get; set; }
 		public long Deuterium { get; set; }
+		public long Food { get; set; }
 		public long Energy { get; set; }
 		public long Darkmatter { get; set; }
 

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -426,6 +426,8 @@ namespace Tbot {
 		}
 
 		private static void WriteSetting(Celestial celestial) {
+			string type = "";
+			if (celestial.Coordinate.Type == Celestials.Moon) type = "Moon" ?? "Planet";
 
 			System.Threading.Thread.Sleep(500);
 			var file = File.ReadAllText($"{Path.GetFullPath(AppContext.BaseDirectory)}/settings.json");
@@ -435,7 +437,7 @@ namespace Tbot {
 			jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
 			jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["System"] = (int) celestial.Coordinate.System;
 			jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["Position"] = (int) celestial.Coordinate.Position;
-			jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["Type"] = (int) celestial.Coordinate.Type;
+			jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["Type"] = type;
 
 			jsonObj["Brain"]["AutoResearch"]["Target"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
 			jsonObj["Brain"]["AutoResearch"]["Target"]["System"] = (int) celestial.Coordinate.System;
@@ -445,23 +447,22 @@ namespace Tbot {
 			jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
 			jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["System"] = (int) celestial.Coordinate.System;
 			jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["Position"] = (int) celestial.Coordinate.Position;
-			jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["Type"] = (int) celestial.Coordinate.Type;
+			jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["Type"] = type;
 
 			jsonObj["Brain"]["AutoRepatriate"]["Target"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
 			jsonObj["Brain"]["AutoRepatriate"]["Target"]["System"] = (int) celestial.Coordinate.System;
 			jsonObj["Brain"]["AutoRepatriate"]["Target"]["Position"] = (int) celestial.Coordinate.Position;
-			jsonObj["Brain"]["AutoRepatriate"]["Target"]["Type"] = (int) celestial.Coordinate.Type;
+			jsonObj["Brain"]["AutoRepatriate"]["Target"]["Type"] = type;
 
 			jsonObj["Expeditions"]["Origin"][0]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
 			jsonObj["Expeditions"]["Origin"][0]["System"] = (int) celestial.Coordinate.System;
 			jsonObj["Expeditions"]["Origin"][0]["Position"] = (int) celestial.Coordinate.Position;
-			jsonObj["Expeditions"]["Origin"][0]["Type"] = (int) celestial.Coordinate.Type;
+			jsonObj["Expeditions"]["Origin"][0]["Type"] = type;
 
 			string output = Newtonsoft.Json.JsonConvert.SerializeObject(jsonObj, Newtonsoft.Json.Formatting.Indented);
 			File.WriteAllText($"{Path.GetFullPath(AppContext.BaseDirectory)}/settings.json", output);
-
-
 		}
+		
 		private static void WriteSetting() {
 			settings = SettingsService.GetSettings();
 		}

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -427,7 +427,8 @@ namespace Tbot {
 
 		private static void WriteSetting(Celestial celestial) {
 			string type = "";
-			if (celestial.Coordinate.Type == Celestials.Moon) type = "Moon" ?? "Planet";
+			if (celestial.Coordinate.Type == Celestials.Moon)
+				type = "Moon" ?? "Planet";
 
 			System.Threading.Thread.Sleep(500);
 			var file = File.ReadAllText($"{Path.GetFullPath(AppContext.BaseDirectory)}/settings.json");
@@ -461,8 +462,9 @@ namespace Tbot {
 
 			string output = Newtonsoft.Json.JsonConvert.SerializeObject(jsonObj, Newtonsoft.Json.Formatting.Indented);
 			File.WriteAllText($"{Path.GetFullPath(AppContext.BaseDirectory)}/settings.json", output);
+
 		}
-		
+
 		private static void WriteSetting() {
 			settings = SettingsService.GetSettings();
 		}
@@ -1019,8 +1021,14 @@ namespace Tbot {
 			return;
 		}
 
-		public static void TelegramSwitch(decimal speed) {
-			Celestial celestial = TelegramGetMainCelestial();
+		public static void TelegramSwitch(decimal speed, Celestial attacked = null) {
+			Celestial celestial;
+
+			if (attacked == null) {
+				celestial = TelegramGetMainCelestial();	
+			} else {
+				celestial = attacked;
+			}
 
 			if ( celestial.Coordinate.Type == Celestials.Planet) {
 				bool hasMoon = celestials.Count(c => c.HasCoords(new Coordinate(celestial.Coordinate.Galaxy, celestial.Coordinate.System, celestial.Coordinate.Position, Celestials.Moon))) == 1;
@@ -1116,15 +1124,7 @@ namespace Tbot {
 				$"{resources}" +
 				"Ships:\n" +
 				$"{ships}");
-			/*
-			telegramMessenger.SendMessage($"{celestial.Coordinate.ToString()}\n\n" +
-				"Resources:\n" +
-				$"{celestial.Resources.Metal.ToString("#,#", CultureInfo.InvariantCulture)} Metal\n" +
-				$"{celestial.Resources.Crystal.ToString("#,#", CultureInfo.InvariantCulture)} Crystal\n" +
-				$"{celestial.Resources.Deuterium.ToString("#,#", CultureInfo.InvariantCulture)} Deuterium\n\n" +
-				"Ships:\n" +
-				$"{celestial.Ships.ToString()}");
-			*/
+
 			return;
 		}
 
@@ -1232,8 +1232,8 @@ namespace Tbot {
 				}
 				else {  //fleetHypotesis.Count() == 0 && forceUnsafe enabled
 					Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Skipping fleetsave from {celestial.ToString()} no Deploy or Harvest possible doing Unsafe..");
-					Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Skipping fleetsave from {celestial.ToString()} Unsafe not implemented yet!..");
-					
+					decimal speed = 100;
+					TelegramSwitch(speed, celestial);
 					/*
 					Need to modify this, going to 1,1,1 is bad, better Harvest near origin SS, Spy near origin SS, colonize near origin SS
 

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -1109,16 +1109,16 @@ namespace Tbot {
 					}
 
 					if (possibleDestinations.Count == 0) {
-						int sys = origin.Coordinate.System;
-						for ( sys = sys-5 ; sys <= sys+5; sys++) {
+						int sys = 0;
+						for ( sys = origin.Coordinate.System - 5 ; sys <= origin.Coordinate.System + 5; sys++) {
 							galaxyInfo = ogamedService.GetGalaxyInfo(origin.Coordinate.Galaxy, sys);
 							harvestablePos = new();
 							foreach (var planet in galaxyInfo.Planets) {
-								if (planet != null && planet.Debris != null && planet.Debris.Resources.TotalResources > 0)
+								if (planet != null && planet.Debris != null && planet.Debris.Resources.TotalResources > 0) {
 									Console.WriteLine(planet.Debris.Resources.TotalResources);
 									possibleDestinations.Add(new(planet.Coordinate.Galaxy, planet.Coordinate.System, planet.Coordinate.Position, Celestials.Debris));
+								}
 							}
-						Helpers.WriteLog(LogType.Info, LogSender.FleetScheduler, $"Checking debris field at: {sys.ToString()}");
 						}
 					}
 

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -1107,7 +1107,7 @@ namespace Tbot {
 							possibleDestinations.Add(new(planet.Coordinate.Galaxy, planet.Coordinate.System, planet.Coordinate.Position, Celestials.Debris));
 						}		
 					}
-					possibleDestinations = new();
+
 					if (possibleDestinations.Count == 0) {
 						int sys = origin.Coordinate.System;
 						for ( sys = sys-5 ; sys <= sys+5; sys++) {

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -951,12 +951,12 @@ namespace Tbot {
 				}
 			}
 
-			Missions mission = Missions.Harvest;
+			Missions mission = Missions.Deploy;
 			List<FleetHypotesis> fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
 
 			if (fleetHypotesis.Count() == 0) {
-				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.ToString()} no Harvest possible doing Deploy..");
-				mission = Missions.Deploy;
+				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.ToString()} no Deploy possible doing Harvest..");
+				mission = Missions.Harvest;
 				fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
 
 				if (fleetHypotesis.Count() == 0 && !forceUnsafe ) {

--- a/TBot/Services/OgamedService.cs
+++ b/TBot/Services/OgamedService.cs
@@ -6,11 +6,14 @@ using Newtonsoft.Json;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text;
+
 
 namespace Tbot.Services {
 	class OgamedService {
 		private string Url { get; set; }
 		private RestClient Client { get; set; }
+
 
 		public OgamedService(Credentials credentials, string host = "127.0.0.1", int port = 8080, string captchaKey = "", ProxySettings proxySettings = null) {
 			ExecuteOgamedExecutable(credentials, host, port, captchaKey, proxySettings);
@@ -19,9 +22,7 @@ namespace Tbot.Services {
 				Timeout = 86400000,
 				ReadWriteTimeout = 86400000
 			};
-			if (credentials.BasicAuthUsername != "" && credentials.BasicAuthPassword != "") {
-				Client.Authenticator = new RestSharp.Authenticators.HttpBasicAuthenticator(credentials.BasicAuthUsername, credentials.BasicAuthPassword);
-			}
+			Client.Authenticator = new RestSharp.Authenticators.HttpBasicAuthenticator(credentials.BasicAuthUsername, credentials.BasicAuthPassword);
 		}
 
 		internal void ExecuteOgamedExecutable(Credentials credentials, string host = "localhost", int port = 8080, string captchaKey = "", ProxySettings proxySettings = null) {
@@ -83,6 +84,7 @@ namespace Tbot.Services {
 					Resource = "/bot/login",
 					Method = Method.GET
 				};
+
 				var result = JsonConvert.DeserializeObject<OgamedResponse>(Client.Execute(request).Content);
 				if (result.Status != "ok")
 					return false;
@@ -97,6 +99,7 @@ namespace Tbot.Services {
 					Resource = "/bot/logout",
 					Method = Method.GET
 				};
+
 				var result = JsonConvert.DeserializeObject<OgamedResponse>(Client.Execute(request).Content);
 				if (result.Status != "ok")
 					return false;
@@ -111,6 +114,7 @@ namespace Tbot.Services {
 					Resource = "/bot/captcha/challengeID",
 					Method = Method.GET
 				};
+
 				var result = JsonConvert.DeserializeObject<OgamedResponse>(Client.Execute(request).Content);
 				if (result != null && result.Status == "ok")
 					return (string) result.Result;
@@ -125,6 +129,7 @@ namespace Tbot.Services {
 					Resource = "/bot/captcha/question/" + challengeID,
 					Method = Method.GET
 				};
+
 				var response = Client.Execute(request);
 				var result = response.RawBytes;
 				if (result != null)
@@ -140,6 +145,7 @@ namespace Tbot.Services {
 					Resource = "/bot/captcha/icons/" + challengeID,
 					Method = Method.GET
 				};
+
 				var response = Client.Execute(request);
 				var result = response.RawBytes;
 				if (result != null)
@@ -155,6 +161,7 @@ namespace Tbot.Services {
 					Resource = $"/bot/captcha/solve",
 					Method = Method.POST,
 				};
+
 				request.AddParameter("challenge_id", challengeID, ParameterType.GetOrPost);
 				request.AddParameter("answer", answer, ParameterType.GetOrPost);
 				Client.Execute(request);
@@ -166,6 +173,7 @@ namespace Tbot.Services {
 				Resource = "/bot/ip",
 				Method = Method.GET
 			};
+
 			try {
 				var result = JsonConvert.DeserializeObject<OgamedResponse>(Client.Execute(request).Content);
 				if (result.Status != "ok") {
@@ -736,6 +744,7 @@ namespace Tbot.Services {
 			request.AddParameter("metal", payload.Metal, ParameterType.GetOrPost);
 			request.AddParameter("crystal", payload.Crystal, ParameterType.GetOrPost);
 			request.AddParameter("deuterium", payload.Deuterium, ParameterType.GetOrPost);
+			request.AddParameter("food", payload.Food, ParameterType.GetOrPost);
 
 			var result = JsonConvert.DeserializeObject<OgamedResponse>(Client.Execute(request).Content);
 			if (result.Status != "ok") {

--- a/TBot/TBot.csproj
+++ b/TBot/TBot.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
-    <PackageReference Include="Telegram.Bot" Version="17.0.0" />
+    <PackageReference Include="Telegram.Bot" Version="18.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
[NEW FEATURES]
[Telegram commands]

/ghostsleep - '/ghostsleep 5' -> Wait for fleets to return, ghost and sleep for 5hours
/ghost - '/ghost 4' -> Ghost fleet for 4 hours
/ghostto - '/ghostto 4 Harvest'
/sleep - '/sleep 1' -> Stop bot, inactive for 1 hours
/recall - '/recall 65656' -> recall fleet id 65656
/wakeup - Wakeup bot
/send - '/send hello dude' -> Send 'hello dude' to current attacker
/stopexpe - Stop sending expedition
/startexpe - Start sending expedition
/collect - Collect planets resources to current moon
/stopautomine - stop brain automine
/startautomine - start brain automine
/celestial - '/celestial 2:45:8 Moon' (Moon/Planet) Update program current celestial target
/getinfo - Get current celestial resources and ships
/switch - '/switch 5' -> switch current celestial resources and fleets to its planet or moon at 50% speed
/editsettings - '/editsettings 2:425:9 moon -> Edit JSON file to change: Expedition, Transport, Repatriate and AutoReseach (Origin/Target) celestial
/ping - Ping bot
/help - Display this help


[GetFleetSaveDestination && AutoFleetSave]

- Debris research is not perform in the same SS anymore, but -5 -> +5 SS (can be increase easily)

- Unsafe does not go to Transport / spy on 1, 1, 1 anymore (useless), basicaly, if the player is on 2:230:7, and his closest planet/moon is closer than 1,1,1 (90% chance), if he has enough fuel to go 1,1,1, he has enough to go to his closest planet, so the bot should not go to 1,1,1.  Even if his closest planet is more far than 1,1,1, bot should go to harvest on near SS instead. Now, its what it do.

- Fleet sending to 1,1,1 was in case of urgency, when nothing else was possible (but if nothing possible it was cuz harvest and deploy was not perfectly working), as previously said, now unsafe goes to the Moon's planet at 100% speed (to avoid phallanx and intercept of fast universe, but the speed can be set randomly or within a range, or with recall)

- Previously, autofleetsave was checking for deploy, and then , without checking if a destination was found, (if the fleet origin was a moon or unsafe true), it went to check for spy, colonize and in last harvest, meaning the deploy fleet was erased, thats why it went to 1,1,1 most of the time when enough fuel was available. (line 950 to 965 of original script), now its not the case anymore. To fix that, FleetHypothesis has been changed to List<FleetHypothesis), to save all valid destination. 

The behavior of AutoFleetSave is as below:

-> check for Deploy destination available (except if /ghostto from telegram is used to chose the mission type)
-> if one or several destination are found, fuel quantity is verified, if Ok -> each destination are sent, if one succed -> break
-> if no Deploy destination are found, or fleet sending did not succeed -> do the same procedure with Harvest destination
-> if no debris field found or no destination could be succesfully sent, it goes to unsafe -> send from moon to pla and vise versa automatically.

Important: Always prefer to enable Recall, mainly if you dont have a moon, and cost less fuel

- MinDuration has been improved to be used with telegram command. Now you can chose you ghost time, and missions, or to ghost with delay (for fleets return), the bot will send to the destination found, and will recall at the half time you specified (you did /ghost 4, it will recall after 2 hours)

Note: Into GetFleetSaveDestination for deploy mission, unsafe param allow to deploy on planet instead of moon, this should be set outside of the unsafe, cuz if no debris field available, its still better to statio (with recall) on planet, than going 1,1,1 transport/spy, or maybe on moon's planet either (TODO).

Note: Changes have been made to not disturb the bot behavior even if telegram is not used

[TBot FIXES]

Fix bug on GetFleetSaveDestination for harvest sending fleet 
Fix bug when bot was sending to transport or spy on 1, 1, 1 without any reason (fuel was enough to statio on player planet)


[MAJOR CODE CHANGES]

Enum types: Added Missions.None types (for telegram /ghostto command purpose, to not disturb "without-telegram" bot behavior)

Private to Public function: Some function have been passed to public in order to used them into telegramMessenger class

Static volatile variables: CurrentMainCelestial (purpose is to not pick static one from json settings)

Static volatile variables: NextWakeUpTime and duration (used with Timers and/ghostsleep, to wakeup when fleet comeback)

Func: WriteSettings (to change Transport origin, repatriate target, autoreseach target, expedition origin into settings.json file from telegram)

Func: WaitFeatures(), RealeaseFeatures(), WaitNotStoppedFeatures() (used on telegram command execution, to not crash the thread)

Func: TelegramCelestial, TelegramSwitch, TelegramGetMainCelestial, TelegramGetInfo (for telegram commands)

Func GhostAndSleepAfterFleetReturn, SleepNow, WakeUpNow:  used with /ghostsleep telegram command

Func Checkfuel: just refactor of previous code to modify behavior of autofleetsave func (even if fuel capacity is check into GetFleetSaveDestination -> double check)

Func TelegramRetireFleet: used with telegram /recall

Func TelegramMesgAttacker: user with telegram /send
