### PR TITLE
TBot Fixes and autofleetsave improved and new telegram features

### DIFF
--- a/TBot/Includes/Helpers.cs
+++ b/TBot/Includes/Helpers.cs
@@ -164,13 +164,13 @@ namespace Tbot.Includes {
 				case Buildables.Recycler:
 					baseCargo = 20000;
 					if (playerClass == CharacterClass.General)
-						bonus += 25;
+						bonus += 20;
 					break;
 				case Buildables.EspionageProbe:
 					baseCargo = probeCargo;
 					break;
 				case Buildables.Bomber:
-					baseCargo = 750;
+					baseCargo = 500;
 					break;
 				case Buildables.Destroyer:
 					baseCargo = 2000;
@@ -182,7 +182,7 @@ namespace Tbot.Includes {
 					baseCargo = 750;
 					break;
 				case Buildables.Reaper:
-					baseCargo = 7000;
+					baseCargo = 10000;
 					break;
 				case Buildables.Pathfinder:
 					baseCargo = 10000;

--- a/TBot/Includes/TelegramMessenger.cs
+++ b/TBot/Includes/TelegramMessenger.cs
@@ -77,6 +77,9 @@ namespace Tbot.Includes {
 				Coordinate coord = new();
 
 				if (commands.Any(x => message.Text.ToLower().Contains(x))) {
+					//Handle /commands@botname in string if exist
+					if (message.Text.Contains("@") && message.Text.Split(" ").Length == 1) 
+						message.Text = message.Text.ToLower().Split(' ')[0].Split('@')[0];
 					
 					try {
 						Tbot.Program.WaitFeature();

--- a/TBot/Includes/TelegramMessenger.cs
+++ b/TBot/Includes/TelegramMessenger.cs
@@ -46,304 +46,450 @@ namespace Tbot.Includes {
 				"/sleep",
 				"/wakeup",
 				"/collect",
+				"/stopautopong",
+				"/startautopong",
 				"stopexpe",
 				"startexpe",
-				"/send",
-				"/ping",
 				"/stopautomine",
 				"/startautomine",
+				"/stopdefender",
+				"/startdefender",
+				"/msg",
+				"/ping",
 				"/getinfo",
 				"/celestial",
-				"/recall",
+				"/cancel",
 				"/editsettings",
+				"/spycrash",
+				"/attacked",
+				"/getcelestials",
+				"/recall",
 				"/help"
 			};
 
 			if (update.Type == UpdateType.Message) {
 				var message = update.Message;
+				var arg = "";
+				var test = "";
+				decimal speed;
+				long duration;
+				Celestial celestial;
+				Coordinate coord = new();
 
 				if (commands.Any(x => message.Text.ToLower().Contains(x))) {
-
+					
 					try {
 						Tbot.Program.WaitFeature();
 
-						if (message.Text.ToLower().Split(' ')[0] == "/ghost") {
-							if (message.Text.Split(' ').Length != 2) {
-								await botClient.SendTextMessageAsync(message.Chat, "Need mission value!");
+						switch (message.Text.ToLower().Split(' ')[0]) {
+
+							case ("/ghost"):
+								if (message.Text.Split(' ').Length != 2) {
+									await botClient.SendTextMessageAsync(message.Chat, "Need 1 value -> ghost duration (eg: /ghost 4)");
+									return;
+								}
+								arg = message.Text.Split(' ')[1];
+								duration = Int32.Parse(arg) * 60 * 60; //second
+
+								celestial = Tbot.Program.TelegramGetCurrentCelestial();
+								Tbot.Program.AutoFleetSave(celestial, false, duration, false, false, Missions.None, true);
+
 								return;
-							}
-							var arg = message.Text.Split(' ')[1];
-							long duration = Int32.Parse(arg) * 60 * 60; //second
 
-							var celestialsToFleetsave = Tbot.Program.UpdateCelestials();
-							celestialsToFleetsave = celestialsToFleetsave.Where(c => c.Coordinate.Type == Celestials.Moon).ToList();
-							if (celestialsToFleetsave.Count() == 0)
-								celestialsToFleetsave = celestialsToFleetsave.Where(c => c.Coordinate.Type == Celestials.Planet).ToList();
 
-							foreach (Celestial celestial in celestialsToFleetsave)
-								Tbot.Program.AutoFleetSave(celestial, false, duration, false, false);
-								
-							return;
+							case ("/ghostto"):
+								if (message.Text.Split(' ').Length != 3) {
+									await botClient.SendTextMessageAsync(message.Chat, "Need ghost duration and destination type (eg: /ghostto 4 harvest)");
+									return;
+								}
+								arg = message.Text.Split(' ')[1];
+								test = message.Text.Split(' ')[2];
+								test = char.ToUpper(test[0]) + test.Substring(1);
+								Missions mission;
 
-						}
-						else if (message.Text.ToLower().Split(' ')[0] == "/ghostto") {
-							if (message.Text.Split(' ').Length != 3) {
-								await botClient.SendTextMessageAsync(message.Chat, "Need mission value!");
+								if (!Missions.TryParse(test, out mission)) {
+									await botClient.SendTextMessageAsync(message.Chat, $"{test} error: Value must be 'Harvest','Deploy','Transport','Spy','Colonize'");
+									return;
+								}
+								duration = Int32.Parse(arg) * 60 * 60; //second
+
+								celestial = Tbot.Program.TelegramGetCurrentCelestial();
+								Tbot.Program.AutoFleetSave(celestial, false, duration, false, false, mission, true);
+
 								return;
-							}
-							var arg = message.Text.Split(' ')[1];
-							var test = message.Text.Split(' ')[2];
-							test = char.ToUpper(test[0]) + test.Substring(1);
-							Missions mission;
 
-							if (!Missions.TryParse(test, out mission)) {
-								await botClient.SendTextMessageAsync(message.Chat, $"{test} error: Value must be 'Harvest','Deploy','Transport','Spy','Colonize'");
+
+							case ("/ghostsleep"):
+								if (message.Text.Split(' ').Length != 3) {
+									await botClient.SendTextMessageAsync(message.Chat, "Need time and destination type (eg /ghostsleep 5 harvest)");
+									return;
+								}
+								arg = message.Text.Split(' ')[1];
+								duration = Int32.Parse(arg) * 60 * 60; //second
+								IsSomeStoppedFeatures = true;
+
+								celestial = Tbot.Program.TelegramGetCurrentCelestial();
+								Tbot.Program.AutoFleetSave(celestial, false, duration, false, true, Missions.None, true);
 								return;
-							}
-							long duration = Int32.Parse(arg) * 60 * 60; //second
 
-							var celestialsToFleetsave = Tbot.Program.UpdateCelestials();
-							celestialsToFleetsave = celestialsToFleetsave.Where(c => c.Coordinate.Type == Celestials.Moon).ToList();
-							if (celestialsToFleetsave.Count() == 0)
-								celestialsToFleetsave = celestialsToFleetsave.Where(c => c.Coordinate.Type == Celestials.Planet).ToList();
 
-							foreach (Celestial celestial in celestialsToFleetsave)
-								Tbot.Program.AutoFleetSave(celestial, false, duration, false, false, mission);
+							case ("/switch"):
+								if (message.Text.Split(' ').Length != 2) {
+									await botClient.SendTextMessageAsync(message.Chat, "Need speed value (eg: 5 for 50%)");
+									return;
+								}
+								test = message.Text.Split(' ')[1];
+								speed = decimal.Parse(test);
 
-							return;
-
-						}
-						else if (message.Text.ToLower().Split(' ')[0] == "/switch") {
-							if (message.Text.Split(' ').Length != 2) {
-								await botClient.SendTextMessageAsync(message.Chat, "Need speed value (eg: 5 for 50%)");
+								if (1 <= speed && speed <= 10) {
+									Tbot.Program.TelegramSwitch(speed);
+									return;
+								}
+								await botClient.SendTextMessageAsync(message.Chat, $"{test} error: Value must be 1 or 2 or 3 for 10%,20%,30% etc.");
 								return;
-							}
-							var test = message.Text.Split(' ')[1];
-							decimal speed = decimal.Parse(test);
 
-							if (1 <= speed && speed <= 10) {
-								Tbot.Program.TelegramSwitch(speed);
+
+							case ("/cancel"):
+								if (message.Text.Split(' ').Length != 2) {
+									await botClient.SendTextMessageAsync(message.Chat, "Need mission value!");
+									return;
+								}
+								arg = message.Text.Split(' ')[1];
+								int fleetId = Int32.Parse(arg);
+
+								Tbot.Program.TelegramRetireFleet(fleetId);
 								return;
-							}
-							await botClient.SendTextMessageAsync(message.Chat, $"{test} error: Value must be 1 or 2 or 3 for 10%,20%,30% etc.");
-							return;
-						}
-						else if (message.Text.ToLower().Split(' ')[0] == "/ghostsleep") {
-							if (message.Text.Split(' ').Length != 2) {
-								await botClient.SendTextMessageAsync(message.Chat, "Need mission value!");
+
+
+							case ("/recall"):
+								if (message.Text.Split(' ').Length < 2) {
+									await botClient.SendTextMessageAsync(message.Chat, "Need true/false value! (enable/disable auto fleets recall)");
+									return;
+								}
+
+								if (message.Text.Split(' ')[1] != "true" && message.Text.Split(' ')[1] != "false") {
+									await botClient.SendTextMessageAsync(message.Chat, "Need true/false value! (enable/disable auto fleets recall)");
+									return;
+								}
+								string recall = message.Text.Split(' ')[1];
+							 
+								if (Tbot.Program.EditSettings(null, recall))
+									await botClient.SendTextMessageAsync(message.Chat, $"Recall value updated to {recall}.");
 								return;
-							}
-							var arg = message.Text.Split(' ')[1];
-							long duration = Int32.Parse(arg) * 60 * 60; //second
 
-							var celestialsToFleetsave = Tbot.Program.UpdateCelestials();
-							celestialsToFleetsave = celestialsToFleetsave.Where(c => c.Coordinate.Type == Celestials.Moon).ToList();
-							if (celestialsToFleetsave.Count() == 0)
-								celestialsToFleetsave = celestialsToFleetsave.Where(c => c.Coordinate.Type == Celestials.Planet).ToList();
 
-							foreach (Celestial celestial in celestialsToFleetsave)
-								Tbot.Program.AutoFleetSave(celestial, false, duration, false, true);
+							case ("/sleep"):
+								if (message.Text.Split(' ').Length != 2) {
+									await botClient.SendTextMessageAsync(message.Chat, "Need mission value!");
+									return;
+								}
+								arg = message.Text.Split(' ')[1];
+								int sleepingtime = Int32.Parse(arg);
 
-							IsSomeStoppedFeatures = true;
-							return;
-						}
-						else if (message.Text.ToLower().Split(' ')[0] == ("/recall")) {
-							if (message.Text.Split(' ').Length != 2) {
-								await botClient.SendTextMessageAsync(message.Chat, "Need mission value!");
-								return;
-							}
-							var arg = message.Text.Split(' ')[1];
-							int fleetId = Int32.Parse(arg);
-
-							Tbot.Program.TelegramRetireFleet(fleetId);
-							return;
-						}
-						else if (message.Text.ToLower().Split(' ')[0] == "/sleep") {
-							if (message.Text.Split(' ').Length != 2) {
-								await botClient.SendTextMessageAsync(message.Chat, "Need mission value!");
-								return;
-							}
-							var arg = message.Text.Split(' ')[1];
-							int sleepingtime = Int32.Parse(arg);
-
-							DateTime timeNow = Tbot.Program.GetDateTime();
-							DateTime WakeUpTime = timeNow.AddHours(sleepingtime);
+								DateTime timeNow = Tbot.Program.GetDateTime();
+								DateTime WakeUpTime = timeNow.AddHours(sleepingtime);
 	
-							Tbot.Program.SleepNow(WakeUpTime);
-							return;
+								Tbot.Program.SleepNow(WakeUpTime);
+								return;
 
+							
+							case ("/wakeup"):
+								if (message.Text.Split(' ').Length != 1) {
+									await botClient.SendTextMessageAsync(message.Chat, "No value needed!");
+									return;
+								}
+								Tbot.Program.WakeUpNow(null);
+								return;
+
+							
+							case ("/msg"):
+								if (message.Text.Split(' ').Length < 2) {
+									await botClient.SendTextMessageAsync(message.Chat, "Need message value!");
+									return;
+								}
+								arg = message.Text.Split(new[] { ' ' }, 2).Last();
+								Tbot.Program.TelegramMesgAttacker(arg);
+								return;
+
+							
+							case ("/stopexpe"):
+								if (message.Text.Split(' ').Length != 1) {
+									await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+									return;
+								}
+
+								Tbot.Program.StopExpeditions();
+								await botClient.SendTextMessageAsync(message.Chat, "Expedition stopped!");
+								return;
+
+							
+							case ("/startexpe"):
+								if (message.Text.Split(' ').Length != 1) {
+									await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+									return;
+								}
+
+								Tbot.Program.InitializeExpeditions();
+								await botClient.SendTextMessageAsync(message.Chat, "Expedition initialized!");
+								return;
+
+
+							case ("/collect"):
+								if (message.Text.Split(' ').Length != 1) {
+									await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+									return;
+								}
+
+								Tbot.Program.InitializeBrainRepatriate();
+								Tbot.Program.AutoRepatriate(null);
+								Tbot.Program.StopBrainRepatriate();
+								return;
+
+
+							case ("/stopautomine"):
+								if (message.Text.Split(' ').Length != 1) {
+									await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+									return;
+								}
+
+								Tbot.Program.StopBrainAutoMine();
+								await botClient.SendTextMessageAsync(message.Chat, "AutoMine stopped!");
+								return;
+
+
+							case ("/startautomine"):
+								if (message.Text.Split(' ').Length != 1) {
+									await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+									return;
+								}
+
+								Tbot.Program.InitializeBrainAutoMine();
+								await botClient.SendTextMessageAsync(message.Chat, "AutoMine started!");
+								return;
+
+							case ("/stopdefender"):
+								if (message.Text.Split(' ').Length != 1) {
+									await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+									return;
+								}
+
+								Tbot.Program.StopDefender();
+								await botClient.SendTextMessageAsync(message.Chat, "Defender stopped!");
+								return;
+
+
+							case ("/startdefender"):
+								if (message.Text.Split(' ').Length != 1) {
+									await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+									return;
+								}
+
+								Tbot.Program.InitializeDefender();
+								await botClient.SendTextMessageAsync(message.Chat, "Defender started!");
+								return;
+
+
+							case ("/getinfo"):
+								if (message.Text.Split(' ').Length != 1) {
+									await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+									return;
+								}
+
+								celestial = Tbot.Program.TelegramGetCurrentCelestial();
+								Tbot.Program.TelegramGetInfo(celestial);
+								return;
+
+
+							case ("/celestial"):
+								if (message.Text.Split(' ').Length != 3) {
+									await botClient.SendTextMessageAsync(message.Chat, "Need coordinate and type! (/celestial 2:56:8 moon/planet)");
+									return;
+								}
+
+								arg = message.Text.ToLower().Split(' ')[2];
+								if ( (!arg.Equals("moon")) && (!arg.Equals("planet")) ) {
+									await botClient.SendTextMessageAsync(message.Chat, $"Need value moon or planet (got {arg})");
+									return;
+								}
+
+								try {
+									coord.Galaxy = Int32.Parse(message.Text.Split(' ')[1].Split(':')[0]);
+									coord.System = Int32.Parse(message.Text.Split(' ')[1].Split(':')[1]);
+									coord.Position = Int32.Parse(message.Text.Split(' ')[1].Split(':')[2]);
+								} catch {
+									await botClient.SendTextMessageAsync(message.Chat, "Error while parsing coordinate! (must be like 3:125:9)");
+									return;
+								}
+
+								arg = char.ToUpper(arg[0]) + arg.Substring(1);
+								Tbot.Program.TelegramSetCurrentCelestial(coord, arg);
+								return;
+
+							
+							case ("/editsettings"):
+								if (message.Text.Split(' ').Length != 3) {
+									await botClient.SendTextMessageAsync(message.Chat, "Need coordinate and type! (/editsettings 2:56:8 moon/planet)");
+									return;
+								}
+
+								arg = message.Text.ToLower().Split(' ')[2];
+								if ((!arg.Equals("moon")) && (!arg.Equals("planet"))) {
+									await botClient.SendTextMessageAsync(message.Chat, $"Need value moon or planet (got {arg})");
+									return;
+								}
+
+								try {
+									coord.Galaxy = Int32.Parse(message.Text.Split(' ')[1].Split(':')[0]);
+									coord.System = Int32.Parse(message.Text.Split(' ')[1].Split(':')[1]);
+									coord.Position = Int32.Parse(message.Text.Split(' ')[1].Split(':')[2]);
+								} catch {
+									await botClient.SendTextMessageAsync(message.Chat, "Error while parsing coordinate! (must be like 3:125:9)");
+									return;
+								}
+
+								arg = char.ToUpper(arg[0]) + arg.Substring(1);
+								Tbot.Program.TelegramSetCurrentCelestial(coord, arg, true);
+								return;
+
+
+							case ("/spycrash"):
+								if (message.Text.Split(' ').Length != 2) {
+									await botClient.SendTextMessageAsync(message.Chat, "Need 'auto' or coordinate (/spycrash auto/2:56:8)");
+									return;
+								}
+
+								Coordinate target;
+								if (message.Text.Split(' ')[1].ToLower().Equals("auto")) {
+									target = null;
+								} else {
+									try {
+										coord.Galaxy = Int32.Parse(message.Text.Split(' ')[1].Split(':')[0]);
+										coord.System = Int32.Parse(message.Text.Split(' ')[1].Split(':')[1]);
+										coord.Position = Int32.Parse(message.Text.Split(' ')[1].Split(':')[2]);
+										target = new Coordinate() { Galaxy = coord.Galaxy, System = coord.System, Position = coord.Position, Type = Celestials.Planet };
+									} catch {
+										await botClient.SendTextMessageAsync(message.Chat, "Error while parsing value! (coord be like 3:125:9, or 'auto')");
+										return;
+									}
+								}
+								Celestial origin = Tbot.Program.TelegramGetCurrentCelestial();
+								
+								Tbot.Program.SpyCrash(origin, target);
+								return;
+
+
+							case ("/attacked"):
+								if (message.Text.Split(' ').Length != 1) {
+									await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+									return;
+								}
+								bool isUnderAttack = Tbot.Program.TelegramIsUnderAttack();
+									
+								if (isUnderAttack) {
+									await botClient.SendTextMessageAsync(message.Chat, "Yes! you're still under attack!");
+								} else {
+									await botClient.SendTextMessageAsync(message.Chat, "Nope! you're safe dude.");
+								}
+								return;
+
+
+							case ("/getcelestials"):
+								if (message.Text.Split(' ').Length != 1) {
+									await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+									return;
+								}
+								List<Celestial> myCelestials = Tbot.Program.celestials.ToList();
+								string listCoords = "";
+								foreach (Coordinate coordinate in myCelestials.Select(p => p.Coordinate)){
+									listCoords += coordinate.ToString() + "\n";
+								}
+									await botClient.SendTextMessageAsync(message.Chat, $"{listCoords}");
+
+								return;
+
+
+							case ("/ping"):
+								if (message.Text.Split(' ').Length != 1) {
+									await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+									return;
+								}
+								await botClient.SendTextMessageAsync(message.Chat, "pong");
+								return;
+
+
+							case ("/stopautopong"):
+								if (message.Text.Split(' ').Length != 1) {
+									await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+									return;
+								}
+								Tbot.Program.StopTelegramAutoPong();
+								await botClient.SendTextMessageAsync(message.Chat, "TelegramAutoPong stopped!");
+								return;
+
+
+							case ("/startautopong"):
+								if (message.Text.Split(' ').Length != 1) {
+									await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+									return;
+								}
+								Tbot.Program.InitializeTelegramAutoPong();
+								await botClient.SendTextMessageAsync(message.Chat, "TelegramAutoPong started!");
+								return;
+
+
+							case ("/help"):
+								if (message.Text.Split(' ').Length != 1) {
+									await botClient.SendTextMessageAsync(message.Chat, "No need value!");
+									return;
+								}
+								await botClient.SendTextMessageAsync(message.Chat,
+									"/ghostsleep - '/ghostsleep 5 Harvest' -> Wait for fleets to return, ghost on harvest and sleep for 5hours\n" +
+									"/ghost - '/ghost 4' -> Ghost fleet for 4 hours\n, let bot chose mission type" +
+									"/ghostto - '/ghostto 4 Harvest'\n" +
+									"/switch - '/switch 5' -> switch current celestial resources and fleets to its planet or moon at 50% speed\n" +
+									"/spycrash - Create a debris field by crashing a probe on target planet\n" +
+									"/recall - '/recall true/false' -> enable/disable fleet auto recall\n" +
+									"/stopexpe - Stop sending expedition\n" +
+									"/startexpe - Start sending expedition\n" +
+									"/startdefender - start defender\n" +
+									"/stopdefender - stop defender\n" +
+									"/stopautomine - stop brain automine\n" +
+									"/startautomine - start brain automine\n" +
+									"/stopautopong - stop telegram autopong\n" +
+									"/startautopong - start telegram autopong (send telegram message every rounded hours)\n" +
+									"/collect - Collect planets resources to JSON setting celestial\n" +
+									"/msg - '/msg hello dude' -> Send 'hello dude' to current attacker\n" +
+									"/sleep - '/sleep 1' -> Stop bot, inactive for 1 hours\n" +
+									"/wakeup - Wakeup bot\n" +
+									"/cancel - '/cancel 65656' -> cancel ongoing fleet id 65656\n" +
+									"/getcelestials - return the coordinate list and type of all your celestials\n" +
+									"/attacked - check if you're (still) under attack\n" +
+									"/celestial - '/celestial 2:45:8 Moon' (Moon/Planet) Update program current celestial target\n" +
+									"/getinfo - Get current celestial resources and ships\n" +
+									"/editsettings - '/editsettings 2:425:9 moon -> Edit JSON file to change: Expedition, Transport, Repatriate and AutoReseach (Origin/Target) celestial\n" + 
+									"/ping - Ping bot\n" +
+									"/help - Display this help"
+								);
+								return;
+							default:
+								return;
 						}
-						else if (message.Text.ToLower().Split(' ')[0] == "/wakeup") {
-							if (message.Text.Split(' ').Length != 1) {
-								await botClient.SendTextMessageAsync(message.Chat, "No value needed!");
-								return;
-							}
-							Tbot.Program.WakeUpNow(null);
-							return;
 
-						}
-						else if (message.Text.ToLower().Split(' ')[0] == "/send") {
-							if (message.Text.Split(' ').Length < 2) {
-								await botClient.SendTextMessageAsync(message.Chat, "Need message value!");
-								return;
-							}
-							var msg = message.Text.Split(new[] { ' ' }, 2).Last();
-							Tbot.Program.TelegramMesgAttacker(msg);
-							return;
+					} catch (ApiRequestException) {
+						await botClient.SendTextMessageAsync(message.Chat, $"ApiRequestException Error!\nTry /ping to check if bot still alive!");
+						return;
 
-						}
-						else if (message.Text.ToLower().Split(' ')[0] == "/stopexpe") {
-							if (message.Text.Split(' ').Length != 1) {
-								await botClient.SendTextMessageAsync(message.Chat, "No need value!");
-								return;
-							}
+					} catch (FormatException) {
+						await botClient.SendTextMessageAsync(message.Chat, $"FormatException Error!\nYou entered an unexpected value (string instead of integer?)\nTry /ping to check if bot still alive!");
+						return;
 
-							Tbot.Program.StopExpeditions();
-							await botClient.SendTextMessageAsync(message.Chat, "Expedition stopped!");
-							return;
+					} catch (NullReferenceException) {
+						await botClient.SendTextMessageAsync(message.Chat, $"NullReferenceException Error!\n Something unknown went wrong!\nTry /ping to check if bot still alive!");
+						return;
 
-						}
-						else if (message.Text.ToLower().Split(' ')[0] == "/startexpe") {
-							if (message.Text.Split(' ').Length != 1) {
-								await botClient.SendTextMessageAsync(message.Chat, "No need value!");
-								return;
-							}
-
-							Tbot.Program.InitializeExpeditions();
-							await botClient.SendTextMessageAsync(message.Chat, "Expedition initialized!");
-
-						}
-						else if (message.Text.ToLower().Split(' ')[0] == "/collect") {
-							if (message.Text.Split(' ').Length != 1) {
-								await botClient.SendTextMessageAsync(message.Chat, "No need value!");
-								return;
-							}
-
-							Tbot.Program.InitializeBrainRepatriate();
-							Tbot.Program.AutoRepatriate(null);
-							Tbot.Program.StopBrainRepatriate();
-							return;
-						}
-						else if (message.Text.ToLower().Split(' ')[0] == "/stopautomine") {
-							if (message.Text.Split(' ').Length != 1) {
-								await botClient.SendTextMessageAsync(message.Chat, "No need value!");
-								return;
-							}
-
-							Tbot.Program.StopBrainAutoMine();
-							await botClient.SendTextMessageAsync(message.Chat, "AutoMine stopped!");
-							return;
-						}
-						else if (message.Text.ToLower().Split(' ')[0] == "/startautomine") {
-							if (message.Text.Split(' ').Length != 1) {
-								await botClient.SendTextMessageAsync(message.Chat, "No need value!");
-								return;
-							}
-
-							Tbot.Program.InitializeBrainAutoMine();
-							await botClient.SendTextMessageAsync(message.Chat, "AutoMine Started!");
-							return;
-						}
-						else if (message.Text.ToLower().Split(' ')[0] == "/getinfo") {
-							if (message.Text.Split(' ').Length != 1) {
-								await botClient.SendTextMessageAsync(message.Chat, "No need value!");
-								return;
-							}
-
-							Tbot.Program.TelegramGetInfo();
-							return;
-						} else if (message.Text.ToLower().Split(' ')[0] == "/celestial") {
-							if (message.Text.Split(' ').Length != 3) {
-								await botClient.SendTextMessageAsync(message.Chat, "Need coordinate and type! (/celestial 2:56:8 moon/planet)");
-								return;
-							}
-
-							Coordinate coord = new();
-							string type = message.Text.ToLower().Split(' ')[2];
-							if ( (!type.Equals("moon")) && (!type.Equals("planet")) ) {
-								await botClient.SendTextMessageAsync(message.Chat, $"Need value moon or planet (got {type})");
-								return;
-							}
-
-							try {
-								coord.Galaxy = Int32.Parse(message.Text.Split(' ')[1].Split(':')[0]);
-								coord.System = Int32.Parse(message.Text.Split(' ')[1].Split(':')[1]);
-								coord.Position = Int32.Parse(message.Text.Split(' ')[1].Split(':')[2]);
-							} catch {
-								await botClient.SendTextMessageAsync(message.Chat, "Error while parsing coordinate! (must be like 3:125:9)");
-								return;
-							}
-
-							type = char.ToUpper(type[0]) + type.Substring(1);
-							Tbot.Program.TelegramCelestial(coord, type);
-							return;
-
-						} else if (message.Text.ToLower().Split(' ')[0] == "/editsettings") {
-							if (message.Text.Split(' ').Length != 3) {
-								await botClient.SendTextMessageAsync(message.Chat, "Need coordinate and type! (/editsettings 2:56:8 moon/planet)");
-								return;
-							}
-
-							Coordinate coord = new();
-							string type = message.Text.ToLower().Split(' ')[2];
-							if ((!type.Equals("moon")) && (!type.Equals("planet"))) {
-								await botClient.SendTextMessageAsync(message.Chat, $"Need value moon or planet (got {type})");
-								return;
-							}
-
-							try {
-								coord.Galaxy = Int32.Parse(message.Text.Split(' ')[1].Split(':')[0]);
-								coord.System = Int32.Parse(message.Text.Split(' ')[1].Split(':')[1]);
-								coord.Position = Int32.Parse(message.Text.Split(' ')[1].Split(':')[2]);
-							} catch {
-								await botClient.SendTextMessageAsync(message.Chat, "Error while parsing coordinate! (must be like 3:125:9)");
-								return;
-							}
-
-							type = char.ToUpper(type[0]) + type.Substring(1);
-							Tbot.Program.TelegramCelestial(coord, type, true);
-							return;
-
-						}
-						else if (message.Text.ToLower().Split(' ')[0] == "/ping") {
-							if (message.Text.Split(' ').Length != 1) {
-								await botClient.SendTextMessageAsync(message.Chat, "No need value!");
-								return;
-							}
-							await botClient.SendTextMessageAsync(message.Chat, "pong");
-							return;
-
-						}
-						else if (message.Text.ToLower().Split(' ')[0] == "/help") {
-							if (message.Text.Split(' ').Length != 1) {
-								await botClient.SendTextMessageAsync(message.Chat, "No need value!");
-								return;
-							}
-							await botClient.SendTextMessageAsync(message.Chat,
-								"/ghostsleep - '/ghostsleep 5' -> Wait for fleets to return, ghost and sleep for 5hours\n" +
-								"/ghost - '/ghost 4' -> Ghost fleet for 4 hours\n" +
-								"/ghostto - '/ghostto 4 Harvest'\n" +
-								"/sleep - '/sleep 1' -> Stop bot, inactive for 1 hours\n" +
-								"/recall - '/recall 65656' -> recall fleet id 65656\n" +
-								"/wakeup - Wakeup bot\n" +
-								"/send - '/send hello dude' -> Send 'hello dude' to current attacker\n" +
-								"/stopexpe - Stop sending expedition\n" +
-								"/startexpe - Start sending expedition\n" +
-								"/collect - Collect planets resources to current moon\n" +
-								"/stopautomine - stop brain automine\n" +
-								"/startautomine - start brain automine\n" +
-								"/celestial - '/celestial 2:45:8 Moon' (Moon/Planet) Update program current celestial target\n" +
-								"/getinfo - Get current celestial resources and ships\n" +
-								"/switch - '/switch 5' -> switch current celestial resources and fleets to its planet or moon at 50% speed\n" +
-								"/editsettings - '/editsettings 2:425:9 moon -> Edit JSON file to change: Expedition, Transport, Repatriate and AutoReseach (Origin/Target) celestial\n" + 
-								"/ping - Ping bot\n" +
-								"/help - Display this help"
-							);
-							return;
-
-						}
-					} catch (NullReferenceException ex) {
-						throw ex;
+					} catch (Exception) {
+						await botClient.SendTextMessageAsync(message.Chat, $"Unknown Exception Error!\nTry /ping to check if bot still alive!");
+						return;
 
 					} finally {
 						if (!IsSomeStoppedFeatures)
@@ -351,13 +497,12 @@ namespace Tbot.Includes {
 						else {
 							Tbot.Program.releaseNotStoppedFeature();
 						}
-
-
 					}
+
+					
 				}
 			}
 		}
-
 
 		async Task HandleErrorAsync(ITelegramBotClient botClient, Exception exception, CancellationToken cancellationToken) {
 			if (exception is ApiRequestException apiRequestException) {

--- a/TBot/Includes/TelegramMessenger.cs
+++ b/TBot/Includes/TelegramMessenger.cs
@@ -80,7 +80,7 @@ namespace Tbot.Includes {
 					//Handle /commands@botname in string if exist
 					if (message.Text.Contains("@") && message.Text.Split(" ").Length == 1) 
 						message.Text = message.Text.ToLower().Split(' ')[0].Split('@')[0];
-					
+
 					try {
 						Tbot.Program.WaitFeature();
 

--- a/TBot/Model/Enums.cs
+++ b/TBot/Model/Enums.cs
@@ -257,7 +257,8 @@ namespace Tbot.Model {
 		FleetScheduler,
 		SleepMode,
 		Colonize,
-		AutoFarm
+		AutoFarm,
+		Telegram
 	}
 
 	public enum Feature {
@@ -273,6 +274,7 @@ namespace Tbot.Model {
 		SleepMode = 9,
 		BrainAutoResearch = 10,
 		Colonize = 11,
-		AutoFarm = 12
+		AutoFarm = 12,
+		TelegramAutoPong = 13
 	}
 }

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -1348,7 +1348,7 @@ namespace Tbot {
 			//Doing Deploy
 			if (!AlreadySent) {
 				if (mission == Missions.Harvest) { mission = Missions.Deploy; } else { mission = Missions.Harvest; };
-				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.ToString()} no Harvest possible, checking {mission}..");
+				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.ToString()} no Harvest possible, checking Deploy..");
 				mission = Missions.Deploy;
 				fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
 				if (fleetHypotesis.Count > 0) {

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -1347,7 +1347,8 @@ namespace Tbot {
 
 			//Doing Deploy
 			if (!AlreadySent) {
-				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.ToString()} no Harvest possible, checking Deploy..");
+				if (mission == Missions.Harvest) { mission = Missions.Deploy; } else { mission = Missions.Harvest; };
+				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.ToString()} no Harvest possible, checking {mission}..");
 				mission = Missions.Deploy;
 				fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
 				if (fleetHypotesis.Count > 0) {

--- a/TBot/Services/OgamedService.cs
+++ b/TBot/Services/OgamedService.cs
@@ -22,7 +22,9 @@ namespace Tbot.Services {
 				Timeout = 86400000,
 				ReadWriteTimeout = 86400000
 			};
-			Client.Authenticator = new RestSharp.Authenticators.HttpBasicAuthenticator(credentials.BasicAuthUsername, credentials.BasicAuthPassword);
+			if (credentials.BasicAuthUsername != "" && credentials.BasicAuthPassword != "") {
+				Client.Authenticator = new RestSharp.Authenticators.HttpBasicAuthenticator(credentials.BasicAuthUsername, credentials.BasicAuthPassword);
+			}
 		}
 
 		internal void ExecuteOgamedExecutable(Credentials credentials, string host = "localhost", int port = 8080, string captchaKey = "", ProxySettings proxySettings = null) {

--- a/TBot/Services/SettingsService.cs
+++ b/TBot/Services/SettingsService.cs
@@ -21,6 +21,8 @@ namespace Tbot.Services {
 		}
 	}
 
+	
+
 	public static class JsonNetAdapter {
 		public static ExpandoObject Transform(ExpandoObject data) {
 			var newExpando = new ExpandoObject();

--- a/TBot/TBot.csproj
+++ b/TBot/TBot.csproj
@@ -5,15 +5,15 @@
     <TargetFramework>net5.0</TargetFramework>
     <Nullable>disable</Nullable>
     <Authors>ELK-Lab</Authors>
-    <Version>0.2.58</Version>
+    <Version>0.2.57</Version>
     <StartupObject>Tbot.Program</StartupObject>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <Copyright>2022 © ELK-Lab</Copyright>
     <PackageLicenseExpression>https://licenses.nuget.org/MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://www.ogame-tbot.net</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ogame-tbot/TBot</RepositoryUrl>
-    <AssemblyVersion>0.2.58.0</AssemblyVersion>
-    <FileVersion>0.2.58.0</FileVersion>
+    <AssemblyVersion>0.2.57.0</AssemblyVersion>
+    <FileVersion>0.2.57.0</FileVersion>
     <Description>OGame Bot</Description>
     <SignAssembly>False</SignAssembly>
     <AssemblyOriginatorKeyFile>ELK-Lab.pfx</AssemblyOriginatorKeyFile>
@@ -42,11 +42,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0" />
+	<PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
     <PackageReference Include="Telegram.Bot" Version="18.0.0" />
+    <PackageReference Include="Telegram.Bot.Extensions.Polling" Version="1.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TBot/settings.json
+++ b/TBot/settings.json
@@ -39,7 +39,8 @@
 			"OnlyMoons": true,
 			"ForceUnsafe": true,
 			"DeutToLeave": 200000,
-			"Recall": true
+			"Recall": true,
+			"DefaultMission": "Harvest"
 		}
 	},
 	"Defender": {
@@ -356,5 +357,8 @@
 		"Active": false,
 		"API": "",
 		"ChatId": ""
+		"TelegramAutoPong": {
+			"Active": true
+		}
 	}
 }


### PR DESCRIPTION
# CHANGES

## TELEGRAM
- Better handling of exception that would make the bot crash.
- /spycrash [auto/coord] [crash a prob at a random target (-2 -> +2 system)] [crash a prob a planet coordinate submitted]
- /getcelestials: list your celestials (usefull to use will /celestial if you dont remember all your coordinate)
- /attacked: say if you're (still) under attack or not
- /startdefender, /stopdefender
- /recall true/false: (prvious /recall changed to /cancel) Enable or disable auto recall fleet when /ghost, /ghostto, /ghostsleep, /deploy and bot autofleetsave (set recall to true/false into JSON settings)
- /startautopong, /stopautopong: send a telegram message every rounded up hours to check if alive (2pm, 3pm, 4pm...)

- Added support of autofleetsave function using TelegramCurrentCelestial (defined by /celestial), this allows to use all /ghost commands and /spycrash, /switch on the desired celestial without editing settings.json file
-> Remember, each Bot features like [TARGET] repatriate (/collect), [ORIGIN] expedition, [TARGET] autoresearch, [ORIGIN] Automine transports will still be via JSON planet information, but you can modify from telegram using /editsettings command.
-> Therefore, do not forget to change celestial focus by using "/celestial" before "/getinfo", "/ghost", "/ghostto", "/ghostsleep", "/switch" or /spycrash commands

You can directly copy/paste the commands list below to your "editcommands" Bot to @BotFather:
 ```
ghostsleep - '/ghostsleep 5 Harvest' -> Wait for fleets to return, ghost on harvest and sleep for 5hours
ghost - '/ghost 4' -> Ghost fleet for 4 hours,let bot chose mission type
ghostto - '/ghostto 4 Harvest'
switch - '/switch 5' -> switch current celestial resources and fleets to its planet or moon at 50% speed
spycrash - Create a debris field by crashing a probe on target planet
recall - '/recall true/false' -> enable/disable fleet auto recall
stopexpe - Stop sending expedition
startexpe - Start sending expedition
startdefender - start defender
stopdefender - stop defender
stopautomine - stop brain automine
startautomine - start brain automine
stopautopong - stop telegram autopong
startautopong - start telegram autopong (send telegram message every rounded hours)
collect - Collect planets resources to JSON setting celestial
msg - '/msg hello dude' -> Send 'hello dude' to current attacker
sleep - '/sleep 1' -> Stop bot, inactive for 1 hours
wakeup - Wakeup bot
cancel - '/cancel 65656' -> cancel ongoing fleet id 65656
getcelestials - return the coordinate list and type of all your celestials
attacked - check if you're (still) under attack
celestial - '/celestial 2:45:8 Moon' (Moon/Planet) Update program current celestial target
getinfo - Get current celestial resources and ships
editsettings - '/editsettings 2:425:9 moon -> Edit JSON file to change: Expedition, Transport, Repatriate and AutoReseach (Origin/Target) celestial
ping - Ping bot
help - Display this help
 ```
 
 
## TBOT 
- Autofleetsave:
->Improved behavior and forceUnsafe removed (now all possibility are checked from safer to unsafer, between getting hit and doing unsafe, i guess u prefer doing unsafe)
-> default mission set to Harvest to consume less fuel (but defaultMission has been added to AutoFleetSave settings to let you chose what you prefer)

### Current autofleetsave behavior:
``` 
1- Check for Default mission into settings to go first (default harvest, harvest/deploy only suggered) (except if from telegram command with mission type submit)
2- Check for available destination, if found, go for it
3- If no destination found or not enough fuel, check for Deploy/harvest depending on previous mission, if found,  go for it
4- If no destination found or not enough fuel, check for Colonize
5- If no destination found or not enough fuel, check for Spy
6- Finally If no destination found or not enough fuel, if planet has a moon, do Switch from moon to pla and vise versa
```

- Feature TelegramAutoPong added -> added to json settings

- Defender: FakeActivity()
-> when "is-under-attack" from defender was made, the last planet visited by the bot was activated (automine, collect, etc), which may make your main planet (ships+resources) inactive for long
-> now fakeactivity() perform activity on one random celestial + your main celestial (from AutoMine.Transport settings) in last, each time defender check for attack, which i believe, fake better a real player

## FIXES
- TelegramMesgAttacker() was sending twice the mesg to the same attacker if several fleet was sent
- GetFleetSaveDestination: fix case Missions.Colonize (not tested)
