### PR TITLE
New Telegram features and TBot fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ OGame Bot
 
 TBot is a .NET 5 [OGame](https://lobby.ogame.gameforge.com/) bot based on [ogamed deamon](https://github.com/alaingilbert/ogame) by alaingilbert
 
-TBot supports Ogame **v8.7.4** and **v9.0.1**!
-Keep in mind that none of the new features are automated yet, but all the old ones work just fine on v9.
+TBot supports Ogame **v9.0.2**!
+Keep in mind that none of the new LifeForm features are automated yet, but all the old ones work just fine on v9.
 
 Feel free to publish issues or pull requests
 
@@ -33,7 +33,8 @@ Do you like the project? Buy me a beer!
 [![Donate with Ethereum](https://en.cryptobadges.io/badge/micro/0x129a661940E4eE0Aff581D0D778d6233722b6557)](https://en.cryptobadges.io/donate/0x129a661940E4eE0Aff581D0D778d6233722b6557)
 
 ## Features
-TBot has a wide variety of useful features. They all can be configured and customized editing settings.json. Here follows a shot explaination of each of them:
+TBot has a wide variety of useful features. They all can be configured and customized editing settings.json.
+Here follows a short explanation of each of them, read the [Wiki](https://github.com/ogame-tbot/TBot/wiki/Configuration-guide) for a more indepth explanation.
 
 * Defender: TBot checks periodically for incoming attacks
   * Autofleet: TBot dispatches your endangered fleet and resources on the safest mission possible

--- a/TBot/Includes/Helpers.cs
+++ b/TBot/Includes/Helpers.cs
@@ -654,7 +654,7 @@ namespace Tbot.Includes {
 			return (long) Math.Round(((float) payload.TotalResources / (float) CalcShipCapacity(buildable, hyperspaceTech, playerClass, probeCapacity)), MidpointRounding.ToPositiveInfinity);
 		}
 
-		public static Ships CalcIdealExpeditionShips(Buildables buildable, int ecoSpeed, long topOnePoints, int hyperspaceTech, CharacterClass playerClass, int probeCargo = 0) {
+		public static Ships CalcIdealExpeditionShips(Buildables buildable, int ecoSpeed, float topOnePoints, int hyperspaceTech, CharacterClass playerClass, int probeCargo = 0) {
 			var fleet = new Ships();
 
 			int freightCap;
@@ -713,7 +713,7 @@ namespace Tbot.Includes {
 				return Buildables.Null;
 		}
 
-		public static Ships CalcExpeditionShips(Ships fleet, Buildables primaryShip, int expeditionsNumber, int ecoSpeed, long topOnePoints, int hyperspaceTech, CharacterClass playerClass, int probeCargo = 0) {
+		public static Ships CalcExpeditionShips(Ships fleet, Buildables primaryShip, int expeditionsNumber, int ecoSpeed, float topOnePoints, int hyperspaceTech, CharacterClass playerClass, int probeCargo = 0) {
 			Ships ideal = CalcIdealExpeditionShips(primaryShip, ecoSpeed, topOnePoints, hyperspaceTech, playerClass, probeCargo);
 			foreach (PropertyInfo prop in fleet.GetType().GetProperties()) {
 				if (prop.Name == primaryShip.ToString()) {

--- a/TBot/Includes/TelegramMessenger.cs
+++ b/TBot/Includes/TelegramMessenger.cs
@@ -67,7 +67,7 @@ namespace Tbot.Includes {
 				"/help"
 			};
 
-			if (update.Type == UpdateType.Message) {
+			if (update.Type == Telegram.Bot.Types.Enums.UpdateType.Message) {
 				var message = update.Message;
 				var arg = "";
 				var test = "";

--- a/TBot/Model/Types.cs
+++ b/TBot/Model/Types.cs
@@ -241,7 +241,7 @@ namespace Tbot.Model {
 		public float RepairFactor { get; set; }
 		public int NewbieProtectionLimit { get; set; }
 		public int NewbieProtectionHigh { get; set; }
-		public long TopScore { get; set; }
+		public float TopScore { get; set; }
 		public int BonusFields { get; set; }
 		public bool DonutGalaxy { get; set; }
 		public bool DonutSystem { get; set; }

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -1670,7 +1670,12 @@ namespace Tbot {
 						Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Delaying...");
 						var time = GetDateTime();
 						fleets = UpdateFleets();
-						long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						long interval;
+						try {
+							interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						} catch {
+							interval = Helpers.CalcRandomInterval((int) settings.AutoResearch.CheckIntervalMin, (int) settings.AutoResearch.CheckIntervalMax);
+						}
 						var newTime = time.AddMilliseconds(interval);
 						timers.GetValueOrDefault("AutoResearchTimer").Change(interval, Timeout.Infinite);
 						Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Next AutoResearch check at {newTime.ToString()}");
@@ -2725,7 +2730,12 @@ namespace Tbot {
 					Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Delaying...");
 					time = GetDateTime();
 					fleets = UpdateFleets();
-					long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+					long interval;
+					try {
+						interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+					} catch {
+						interval = Helpers.CalcRandomInterval((int) settings.AutoMine.CheckIntervalMin, (int) settings.AutoMine.CheckIntervalMax);
+					}
 					if (timers.TryGetValue(autoMineTimer, out Timer value))
 						value.Dispose();
 					timers.Remove(autoMineTimer);
@@ -3216,7 +3226,12 @@ namespace Tbot {
 						Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Delaying...");						
 						fleets = UpdateFleets();
 						var time = GetDateTime();
-						long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						long interval;
+						try {
+							interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						} catch {
+							interval = Helpers.CalcRandomInterval((int) settings.AutoRepatriate.CheckIntervalMin, (int) settings.AutoRepatriate.CheckIntervalMax);
+						}
 						var newTime = time.AddMilliseconds(interval);
 						timers.GetValueOrDefault("RepatriateTimer").Change(interval, Timeout.Infinite);
 						Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Next repatriate check at {newTime.ToString()}");
@@ -3790,7 +3805,12 @@ namespace Tbot {
 						Helpers.WriteLog(LogType.Info, LogSender.Expeditions, $"Delaying...");
 						var time = GetDateTime();
 						fleets = UpdateFleets();
-						long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						long interval;
+						try {
+							interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						} catch {
+							interval = Helpers.CalcRandomInterval((int) settings.Expeditions.CheckIntervalMin, (int) settings.Expeditions.CheckIntervalMax);
+						}
 						var newTime = time.AddMilliseconds(interval);
 						timers.GetValueOrDefault("ExpeditionsTimer").Change(interval, Timeout.Infinite);
 						Helpers.WriteLog(LogType.Info, LogSender.Expeditions, $"Next check at {newTime.ToString()}");
@@ -3972,7 +3992,12 @@ namespace Tbot {
 						Helpers.WriteLog(LogType.Info, LogSender.Harvest, $"Delaying...");
 						var time = GetDateTime();
 						fleets = UpdateFleets();
-						long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						long interval;
+						try {
+							interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						} catch {
+							interval = Helpers.CalcRandomInterval((int) settings.AutoHarvest.CheckIntervalMin, (int) settings.AutoHarvest.CheckIntervalMax);
+						}
 						var newTime = time.AddMilliseconds(interval);
 						timers.GetValueOrDefault("HarvestTimer").Change(interval, Timeout.Infinite);
 						Helpers.WriteLog(LogType.Info, LogSender.Harvest, $"Next check at {newTime.ToString()}");
@@ -4140,7 +4165,13 @@ namespace Tbot {
 						Helpers.WriteLog(LogType.Info, LogSender.Colonize, $"Delaying...");
 						var time = GetDateTime();
 						fleets = UpdateFleets();
-						long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						long interval;
+						try {
+							interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						}
+						catch {
+							interval = Helpers.CalcRandomInterval((int) settings.AutoColonize.CheckIntervalMin, (int) settings.AutoColonize.CheckIntervalMax);
+						}
 						var newTime = time.AddMilliseconds(interval);
 						timers.GetValueOrDefault("ColonizeTimer").Change(interval, Timeout.Infinite);
 						Helpers.WriteLog(LogType.Info, LogSender.Colonize, $"Next check at {newTime}");

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -21,7 +21,7 @@ namespace Tbot {
 		static volatile Server serverInfo;
 		static volatile ServerData serverData;
 		static volatile UserInfo userInfo;
-		static volatile List<Celestial> celestials;
+		public static volatile List<Celestial> celestials;
 		static volatile List<Fleet> fleets;
 		static volatile List<AttackerFleet> attacks;
 		static volatile Slots slots;
@@ -36,13 +36,14 @@ namespace Tbot {
 		static Dictionary<Feature, Semaphore> xaSem = new();
 		static long duration;
 		static DateTime NextWakeUpTime;
-		public static volatile Celestial CurrentMainCelestial;
+		public static volatile Celestial TelegramCurrentCelestial;
 
 		static void Main(string[] args) {
 			Helpers.SetTitle();
 			isSleeping = false;
 
 			ReadSettings();
+
 			PhysicalFileProvider physicalFileProvider = new(Path.GetFullPath(AppContext.BaseDirectory));
 			var changeToken = physicalFileProvider.Watch("settings.json");
 			changeToken.RegisterChangeCallback(OnSettingsChanged, default);
@@ -171,8 +172,9 @@ namespace Tbot {
 					xaSem[Feature.Expeditions] = new Semaphore(1, 1);
 					xaSem[Feature.Harvest] = new Semaphore(1, 1);
 					xaSem[Feature.Colonize] = new Semaphore(1, 1);
-					xaSem[Feature.FleetScheduler] = new Semaphore(1, 3);
+					xaSem[Feature.FleetScheduler] = new Semaphore(1, 1);
 					xaSem[Feature.SleepMode] = new Semaphore(1, 1);
+					xaSem[Feature.TelegramAutoPong] = new Semaphore(1, 1);
 
 					features = new();
 					features.AddOrUpdate(Feature.Defender, false, HandleStartStopFeatures);
@@ -188,6 +190,7 @@ namespace Tbot {
 					features.AddOrUpdate(Feature.Harvest, false, HandleStartStopFeatures);
 					features.AddOrUpdate(Feature.FleetScheduler, false, HandleStartStopFeatures);
 					features.AddOrUpdate(Feature.SleepMode, false, HandleStartStopFeatures);
+					features.AddOrUpdate(Feature.TelegramAutoPong, false, HandleStartStopFeatures);
 
 					Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Initializing data...");
 					celestials = GetPlanets();
@@ -283,6 +286,11 @@ namespace Tbot {
 						if (!currentValue)
 							InitializeSleepMode();
 						return true;
+					case Feature.TelegramAutoPong:
+						if (currentValue)
+							StopTelegramAutoPong();
+						return false;
+						
 					default:
 						return false;
 				}
@@ -400,6 +408,15 @@ namespace Tbot {
 							StopSleepMode();
 						return false;
 					}
+				case Feature.TelegramAutoPong:
+					if ((bool) settings.TelegramMessenger.TelegramAutoPong.Active) {
+						InitializeTelegramAutoPong();
+						return true;
+					} else {
+						if (currentValue)
+							StopTelegramAutoPong();
+						return false;
+					}
 				default:
 					return false;
 			}
@@ -418,54 +435,58 @@ namespace Tbot {
 			features.AddOrUpdate(Feature.Expeditions, false, HandleStartStopFeatures);
 			features.AddOrUpdate(Feature.Harvest, false, HandleStartStopFeatures);
 			features.AddOrUpdate(Feature.Colonize, false, HandleStartStopFeatures);
+			features.AddOrUpdate(Feature.TelegramAutoPong, false, HandleStartStopFeatures);
 		}
 
 		private static void ReadSettings() {
 			settings = SettingsService.GetSettings();
 		}
 
-		private static void WriteSetting(Celestial celestial) {
-			string type = "";
-			if (celestial.Coordinate.Type == Celestials.Moon)
-				type = "Moon" ?? "Planet";
-
+		public static bool EditSettings(Celestial celestial = null, string recall = "") {
 			System.Threading.Thread.Sleep(500);
 			var file = File.ReadAllText($"{Path.GetFullPath(AppContext.BaseDirectory)}/settings.json");
 			var jsonObj = new JObject();
 			jsonObj = Newtonsoft.Json.JsonConvert.DeserializeObject<dynamic>(file);
 
-			jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
-			jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["System"] = (int) celestial.Coordinate.System;
-			jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["Position"] = (int) celestial.Coordinate.Position;
-			jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["Type"] = type;
+			if (recall != "") {
+				jsonObj["SleepMode"]["AutoFleetSave"]["Recall"] = Convert.ToBoolean(recall);
+			}
 
-			jsonObj["Brain"]["AutoResearch"]["Target"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
-			jsonObj["Brain"]["AutoResearch"]["Target"]["System"] = (int) celestial.Coordinate.System;
-			jsonObj["Brain"]["AutoResearch"]["Target"]["Position"] = (int) celestial.Coordinate.Position;
-			jsonObj["Brain"]["AutoResearch"]["Target"]["Type"] = (int) Celestials.Planet;
+			if (celestial != null) {
+				string type = "";
+				if (celestial.Coordinate.Type == Celestials.Moon)
+					type = "Moon" ?? "Planet";
 
-			jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
-			jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["System"] = (int) celestial.Coordinate.System;
-			jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["Position"] = (int) celestial.Coordinate.Position;
-			jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["Type"] = type;
+				jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
+				jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["System"] = (int) celestial.Coordinate.System;
+				jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["Position"] = (int) celestial.Coordinate.Position;
+				jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["Type"] = type;
 
-			jsonObj["Brain"]["AutoRepatriate"]["Target"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
-			jsonObj["Brain"]["AutoRepatriate"]["Target"]["System"] = (int) celestial.Coordinate.System;
-			jsonObj["Brain"]["AutoRepatriate"]["Target"]["Position"] = (int) celestial.Coordinate.Position;
-			jsonObj["Brain"]["AutoRepatriate"]["Target"]["Type"] = type;
+				jsonObj["Brain"]["AutoResearch"]["Target"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
+				jsonObj["Brain"]["AutoResearch"]["Target"]["System"] = (int) celestial.Coordinate.System;
+				jsonObj["Brain"]["AutoResearch"]["Target"]["Position"] = (int) celestial.Coordinate.Position;
+				jsonObj["Brain"]["AutoResearch"]["Target"]["Type"] = "Planet";
 
-			jsonObj["Expeditions"]["Origin"][0]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
-			jsonObj["Expeditions"]["Origin"][0]["System"] = (int) celestial.Coordinate.System;
-			jsonObj["Expeditions"]["Origin"][0]["Position"] = (int) celestial.Coordinate.Position;
-			jsonObj["Expeditions"]["Origin"][0]["Type"] = type;
+				jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
+				jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["System"] = (int) celestial.Coordinate.System;
+				jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["Position"] = (int) celestial.Coordinate.Position;
+				jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["Type"] = type;
+
+				jsonObj["Brain"]["AutoRepatriate"]["Target"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
+				jsonObj["Brain"]["AutoRepatriate"]["Target"]["System"] = (int) celestial.Coordinate.System;
+				jsonObj["Brain"]["AutoRepatriate"]["Target"]["Position"] = (int) celestial.Coordinate.Position;
+				jsonObj["Brain"]["AutoRepatriate"]["Target"]["Type"] = type;
+
+				jsonObj["Expeditions"]["Origin"][0]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
+				jsonObj["Expeditions"]["Origin"][0]["System"] = (int) celestial.Coordinate.System;
+				jsonObj["Expeditions"]["Origin"][0]["Position"] = (int) celestial.Coordinate.Position;
+				jsonObj["Expeditions"]["Origin"][0]["Type"] = type;
+			}
 
 			string output = Newtonsoft.Json.JsonConvert.SerializeObject(jsonObj, Newtonsoft.Json.Formatting.Indented);
 			File.WriteAllText($"{Path.GetFullPath(AppContext.BaseDirectory)}/settings.json", output);
 
-		}
-
-		private static void WriteSetting() {
-			settings = SettingsService.GetSettings();
+			return true;
 		}
 
 		public static void WaitFeature() {
@@ -494,7 +515,8 @@ namespace Tbot {
 			xaSem[Feature.SleepMode].WaitOne();
 		}
 
-		private static void OnSettingsChanged(object sender) {
+		private static void OnSettingsChanged(object state) {
+
 			xaSem[Feature.Defender].WaitOne();
 			xaSem[Feature.Brain].WaitOne();
 			xaSem[Feature.Expeditions].WaitOne();
@@ -502,6 +524,7 @@ namespace Tbot {
 			xaSem[Feature.Colonize].WaitOne();
 			xaSem[Feature.AutoFarm].WaitOne();
 			xaSem[Feature.SleepMode].WaitOne();
+			xaSem[Feature.TelegramAutoPong].WaitOne();
 
 			Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Settings file changed");
 			ReadSettings();
@@ -513,6 +536,7 @@ namespace Tbot {
 			xaSem[Feature.Colonize].Release();
 			xaSem[Feature.AutoFarm].Release();
 			xaSem[Feature.SleepMode].Release();
+			xaSem[Feature.TelegramAutoPong].Release();
 
 			InitializeSleepMode();
 			UpdateTitle();
@@ -818,18 +842,40 @@ namespace Tbot {
 			}
 		}
 
-		private static void InitializeDefender() {
+		public static void InitializeTelegramAutoPong() {
+			DateTime now = GetDateTime();
+			long everyHours = 0;
+			if ((bool) settings.TelegramMessenger.TelegramAutoPong.Active) {
+				everyHours = settings.TelegramMessenger.TelegramAutoPong.EveryHours;
+			}
+			DateTime roundedNextHour = now.AddHours(everyHours).AddMinutes(-now.Minute).AddSeconds(-now.Second);
+			long nextpong = (long) roundedNextHour.Subtract(now).TotalMilliseconds;
+			
+			Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Initializing TelegramAutoPong...");
+			StopTelegramAutoPong(false);
+			timers.Add("TelegramAutoPong", new Timer(TelegramAutoPong, null, nextpong, Timeout.Infinite));
+		}
+
+		public static void StopTelegramAutoPong(bool echo = true) {
+			if (echo)
+				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping TelegramAutoPong...");
+			if (timers.TryGetValue("TelegramAutoPong", out Timer value))
+				value.Dispose();
+				timers.Remove("TelegramAutoPong");
+		}
+
+		public static void InitializeDefender() {
 			Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Initializing defender...");
 			StopDefender(false);
 			timers.Add("DefenderTimer", new Timer(Defender, null, Helpers.CalcRandomInterval(IntervalType.AFewSeconds), Timeout.Infinite));
 		}
 
-		private static void StopDefender(bool echo = true) {
+		public static void StopDefender(bool echo = true) {
 			if (echo)
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping defender...");
 			if (timers.TryGetValue("DefenderTimer", out Timer value))
 				value.Dispose();
-			timers.Remove("DefenderTimer");
+				timers.Remove("DefenderTimer");
 		}
 
 		private static void InitializeBrainAutoCargo() {
@@ -843,7 +889,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping autocargo...");
 			if (timers.TryGetValue("CapacityTimer", out Timer value))
 				value.Dispose();
-			timers.Remove("CapacityTimer");
+				timers.Remove("CapacityTimer");
 		}
 
 		public static void InitializeBrainRepatriate() {
@@ -857,7 +903,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping repatriate...");
 			if (timers.TryGetValue("RepatriateTimer", out Timer value))
 				value.Dispose();
-			timers.Remove("RepatriateTimer");
+				timers.Remove("RepatriateTimer");
 		}
 
 		public static void InitializeBrainAutoMine() {
@@ -875,7 +921,7 @@ namespace Tbot {
 			foreach (var celestial in celestials) {
 				if (timers.TryGetValue($"AutoMineTimer-{celestial.ID.ToString()}", out value))
 					value.Dispose();
-				timers.Remove($"AutoMineTimer-{celestial.ID.ToString()}");
+					timers.Remove($"AutoMineTimer-{celestial.ID.ToString()}");
 			}
 		}
 
@@ -890,7 +936,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping offer of the day...");
 			if (timers.TryGetValue("OfferOfTheDayTimer", out Timer value))
 				value.Dispose();
-			timers.Remove("OfferOfTheDayTimer");
+				timers.Remove("OfferOfTheDayTimer");
 		}
 
 		private static void InitializeBrainAutoResearch() {
@@ -904,7 +950,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping autoresearch...");
 			if (timers.TryGetValue("AutoResearchTimer", out Timer value))
 				value.Dispose();
-			timers.Remove("AutoResearchTimer");
+				timers.Remove("AutoResearchTimer");
 		}
 
 		private static void InitializeAutoFarm() {
@@ -918,7 +964,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping autofarm...");
 			if (timers.TryGetValue("AutoFarmTimer", out Timer value))
 				value.Dispose();
-			timers.Remove("AutoFarmTimer");
+				timers.Remove("AutoFarmTimer");
 		}
 
 		public static void InitializeExpeditions() {
@@ -932,7 +978,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping expeditions...");
 			if (timers.TryGetValue("ExpeditionsTimer", out Timer value))
 				value.Dispose();
-			timers.Remove("ExpeditionsTimer");
+				timers.Remove("ExpeditionsTimer");
 		}
 
 		private static void InitializeHarvest() {
@@ -946,7 +992,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping harvest...");
 			if (timers.TryGetValue("HarvestTimer", out Timer value))
 				value.Dispose();
-			timers.Remove("HarvestTimer");
+				timers.Remove("HarvestTimer");
 		}
 
 		private static void InitializeColonize() {
@@ -960,7 +1006,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping colonize...");
 			if (timers.TryGetValue("ColonizeTimer", out Timer value))
 				value.Dispose();
-			timers.Remove("ColonizeTimer");
+				timers.Remove("ColonizeTimer");
 		}
 
 		private static void InitializeSleepMode() {
@@ -974,7 +1020,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping sleep mode...");
 			if (timers.TryGetValue("SleepModeTimer", out Timer value))
 				value.Dispose();
-			timers.Remove("SleepModeTimer");
+				timers.Remove("SleepModeTimer");
 		}
 		
 		private static void InitializeFleetScheduler() {
@@ -989,47 +1035,37 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping fleet scheduler...");
 			if (timers.TryGetValue("FleetSchedulerTimer", out Timer value))
 				value.Dispose();
-			timers.Remove("FleetSchedulerTimer");
+				timers.Remove("FleetSchedulerTimer");
 		}
 
-		public static void TelegramCelestial(Coordinate coord, string type, bool editsettings = false) {
-			celestials = UpdateCelestials();
 
-			CurrentMainCelestial = celestials
-				.Unique()
-				.Where(c => c.Coordinate.Galaxy == (int) coord.Galaxy)
-				.Where(c => c.Coordinate.System == (int) coord.System)
-				.Where(c => c.Coordinate.Position == (int) coord.Position)
-				.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>(type))
-				.SingleOrDefault() ?? new() { ID = 0 };
+		public static void TelegramAutoPong(object state) {
+			xaSem[Feature.TelegramAutoPong].WaitOne();
+			DateTime time = GetDateTime();
+			DateTime newTime = time.AddMilliseconds(3600000);
+			timers.GetValueOrDefault("TelegramAutoPong").Change(3600000, Timeout.Infinite);
+			Helpers.WriteLog(LogType.Info, LogSender.Telegram, $"Next check at {newTime.ToString()}");
+			telegramMessenger.SendMessage("[TBot] Alive");
+			xaSem[Feature.TelegramAutoPong].Release();
 
-			if (CurrentMainCelestial.ID == 0) {
-				telegramMessenger.SendMessage("Error! Could not update main celestial with wrong information. Verify coordinate.");
-				return;
-			}
-			if (editsettings) {
-				WriteSetting(CurrentMainCelestial);
-				telegramMessenger.SendMessage($"JSON settings updated to: {CurrentMainCelestial.Coordinate.ToString()}");
-			} else {
-				telegramMessenger.SendMessage($"Main celestial successfuly updated to {CurrentMainCelestial.Coordinate.ToString()}");
-			}
 			return;
 		}
 
-		public static void TelegramSwitch(decimal speed, Celestial attacked = null) {
+		public static bool TelegramSwitch(decimal speed, Celestial attacked = null, bool fromTelegram = false) {
 			Celestial celestial;
 
 			if (attacked == null) {
-				celestial = TelegramGetMainCelestial();	
+				celestial = TelegramGetCurrentCelestial();	
 			} else {
-				celestial = attacked;
+				celestial = attacked; //for autofleetsave func when under attack, last option if no other destination found.
 			}
 
 			if ( celestial.Coordinate.Type == Celestials.Planet) {
 				bool hasMoon = celestials.Count(c => c.HasCoords(new Coordinate(celestial.Coordinate.Galaxy, celestial.Coordinate.System, celestial.Coordinate.Position, Celestials.Moon))) == 1;
 				if (!hasMoon) {
-					telegramMessenger.SendMessage($"This planet does not have a Moon dumbass!");
-					return;
+					if ((bool) settings.TelegramMessenger.Active || fromTelegram)
+						telegramMessenger.SendMessage($"This planet does not have a Moon! Switch impossible.");
+					return false;
 				}
 			}
 			
@@ -1048,60 +1084,81 @@ namespace Tbot {
 			celestial = UpdatePlanet(celestial, UpdateTypes.Ships);
 
 			if (celestial.Ships.GetMovableShips().IsEmpty()) {
-				telegramMessenger.SendMessage($"No ships on {celestial.Coordinate}, did you /celestial?");
-				return;
+				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"[Switch] Skipping fleetsave from {celestial.Coordinate.ToString()}: No ships!");
+				if ((bool) settings.TelegramMessenger.Active || fromTelegram)
+					telegramMessenger.SendMessage($"No ships on {celestial.Coordinate}, did you /celestial?");
+				return false;
 			}
 
 			var payload = celestial.Resources;
 			if (celestial.Resources.Deuterium == 0) {
-				telegramMessenger.SendMessage($"Skipping fleetsave from {celestial.Coordinate.ToString()}: there is no fuel!");
-				return;
+				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"[Switch] Skipping fleetsave from { celestial.Coordinate.ToString()}: there is no fuel!");
+				if ((bool) settings.TelegramMessenger.Active || fromTelegram)
+					telegramMessenger.SendMessage($"Skipping fleetsave from {celestial.Coordinate.ToString()}: there is no fuel!");
+				return false;
 			}
 
 			FleetPrediction fleetPrediction = Helpers.CalcFleetPrediction(celestial.Coordinate, dest, celestial.Ships, Missions.Deploy, speed, researches, serverData, userInfo.Class);
 			int fleetId = SendFleet(celestial, celestial.Ships, dest, Missions.Deploy, speed, payload, userInfo.Class, true);
 
 			if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
-				telegramMessenger.SendMessage($"Fleet {fleetId} switched from {celestial.Coordinate.Type} to {dest.Type}\nPredicted time: {TimeSpan.FromSeconds(fleetPrediction.Time).ToString()}");
+				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleet {fleetId} switched from {celestial.Coordinate.Type} to {dest.Type}\nPredicted time: {TimeSpan.FromSeconds(fleetPrediction.Time).ToString()}");
+				if ((bool) settings.TelegramMessenger.Active || fromTelegram)
+					telegramMessenger.SendMessage($"Fleet {fleetId} switched from {celestial.Coordinate.Type} to {dest.Type}\nPredicted time: {TimeSpan.FromSeconds(fleetPrediction.Time).ToString()}");
+				return true;
 			}
-			else {
-				Helpers.WriteLog(LogType.Info, LogSender.FleetScheduler, $"Telegram switch failed to sent on {dest.ToString()}");
-				telegramMessenger.SendMessage($"Telegram switch failed to sent on {dest.ToString()}");
+
+			return false;
+		}
+
+		public static void TelegramSetCurrentCelestial(Coordinate coord, string type, bool editsettings = false) {
+			celestials = UpdateCelestials();
+
+			//check if no error in submitted celestial (belongs to the current player)
+			TelegramCurrentCelestial = celestials
+				.Unique()
+				.Where(c => c.Coordinate.Galaxy == (int) coord.Galaxy)
+				.Where(c => c.Coordinate.System == (int) coord.System)
+				.Where(c => c.Coordinate.Position == (int) coord.Position)
+				.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>(type))
+				.SingleOrDefault() ?? new() { ID = 0 };
+
+			if (TelegramCurrentCelestial.ID == 0) {
+				telegramMessenger.SendMessage("Error! Wrong information. Verify coordinate.\n");
+				return;
+			}
+			if (editsettings) {
+				EditSettings(TelegramCurrentCelestial);
+				telegramMessenger.SendMessage($"JSON settings updated to: {TelegramCurrentCelestial.Coordinate.ToString()}\nWait few seconds for Bot to reload before sending commands.");
+			} else {
+				telegramMessenger.SendMessage($"Main celestial successfuly updated to {TelegramCurrentCelestial.Coordinate.ToString()}");
 			}
 			return;
 		}
 
-		private static Celestial TelegramGetMainCelestial() {
-			celestials = UpdateCelestials();
-			Celestial celestial;
-			celestial = celestials
-				.Unique()
-				.Where(c => c.Coordinate.Galaxy == (int) settings.Brain.AutoMine.Transports.Origin.Galaxy)
-				.Where(c => c.Coordinate.System == (int) settings.Brain.AutoMine.Transports.Origin.System)
-				.Where(c => c.Coordinate.Position == (int) settings.Brain.AutoMine.Transports.Origin.Position)
-				.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) settings.Brain.AutoMine.Transports.Origin.Type))
-				.SingleOrDefault() ?? new() { ID = 0 };
+		public static Celestial TelegramGetCurrentCelestial() {
+			if (TelegramCurrentCelestial == null) {
+				Celestial celestial;
+				celestial = celestials
+					.Unique()
+					.Where(c => c.Coordinate.Galaxy == (int) settings.Brain.AutoMine.Transports.Origin.Galaxy)
+					.Where(c => c.Coordinate.System == (int) settings.Brain.AutoMine.Transports.Origin.System)
+					.Where(c => c.Coordinate.Position == (int) settings.Brain.AutoMine.Transports.Origin.Position)
+					.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) settings.Brain.AutoMine.Transports.Origin.Type))
+					.SingleOrDefault() ?? new() { ID = 0 };
 
-			if (celestial.ID == 0) {
-				telegramMessenger.SendMessage("Error! Could not parse Celestial from JSON settings.");
-				return new Celestial();
+				if (celestial.ID == 0) {
+					telegramMessenger.SendMessage("Error! Could not parse Celestial from JSON settings (Need /editsettings)");
+					return new Celestial();
+				}
+
+				TelegramCurrentCelestial = celestial;
 			}
 
-			if (CurrentMainCelestial == null) 
-				CurrentMainCelestial = celestial;
-
-			string check = celestial.Coordinate.ToString();
-			if (!check.Equals(CurrentMainCelestial.Coordinate.ToString())) {
-				telegramMessenger.SendMessage($"JSON data:{celestial.Coordinate.ToString()}\nCarefull, Your program current Main Celestial differ from the local settings one. Modify your JSON file (AutoMine.Transports) or /editsettings.");
-				celestial = CurrentMainCelestial;
-			}
-
-			return celestial;
+			return TelegramCurrentCelestial;
 		}
 
-		public static void TelegramGetInfo() {
-			Celestial celestial = TelegramGetMainCelestial();
-			if (celestial == null) { telegramMessenger.SendMessage($"Could not get Celestial, did you /update?"); return; }
+		public static void TelegramGetInfo(Celestial celestial) {
 
 			celestial = UpdatePlanet(celestial, UpdateTypes.Resources);
 			celestial = UpdatePlanet(celestial, UpdateTypes.Ships);
@@ -1123,7 +1180,59 @@ namespace Tbot {
 			return;
 		}
 
-		public static void AutoFleetSave(Celestial celestial, bool isSleepTimeFleetSave = false, long minDuration = 0, bool forceUnsafe = false, bool WaitFleetsReturn = false, Missions TelegramMission = Missions.None) {
+
+		public static void SpyCrash(Celestial fromCelestial, Coordinate target = null) {
+			decimal speed = Speeds.HundredPercent;
+			fromCelestial = UpdatePlanet(fromCelestial, UpdateTypes.Ships);
+			var payload = fromCelestial.Resources;
+			Random random = new Random();
+
+			if (fromCelestial.Ships.EspionageProbe == 0 || payload.Deuterium < 1) {
+				Helpers.WriteLog(LogType.Info, LogSender.FleetScheduler, $"No probes or no Fuel on {fromCelestial.Coordinate.ToString()}!");
+				telegramMessenger.SendMessage($"No probes or no Fuel on {fromCelestial.Coordinate.ToString()}!");
+				return;
+			}
+			// spycrash auto part
+			if (target == null) {
+				List<Coordinate> spycrash = new();
+				int playerid = userInfo.PlayerID;
+				int sys = 0;
+				for ( sys = fromCelestial.Coordinate.System - 2 ; sys <= fromCelestial.Coordinate.System + 2; sys++) {
+					GalaxyInfo galaxyInfo = ogamedService.GetGalaxyInfo(fromCelestial.Coordinate.Galaxy, sys);
+					foreach (var planet in galaxyInfo.Planets) {
+						try {
+							if (planet != null && !planet.Administrator && !planet.Inactive && !planet.StrongPlayer && !planet.Newbie && !planet.Banned && !planet.Vacation) {
+								if (planet.Player.ID != playerid) { //exclude player planet
+									spycrash.Add(new(planet.Coordinate.Galaxy, planet.Coordinate.System, planet.Coordinate.Position, Celestials.Planet));
+								}
+							}
+						} catch (NullReferenceException) {
+							continue;
+						}
+					}
+				}
+
+				if (spycrash.Count() == 0) {
+					telegramMessenger.SendMessage($"No planet to spycrash on could be found (over system -2 -> +2)");
+					return;
+				} else {
+					target = spycrash[random.Next(spycrash.Count())];
+				}
+			}
+			var attackingShips = new Ships().Add(Buildables.EspionageProbe, 1);
+
+			int fleetId = SendFleet(fromCelestial, attackingShips, target, Missions.Attack, speed);
+
+			if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
+				Helpers.WriteLog(LogType.Info, LogSender.FleetScheduler, $"EspionageProbe sent to crash on {target.ToString()}");
+
+				telegramMessenger.SendMessage($"EspionageProbe sent to crash on {target.ToString()}");
+			}
+			return;
+		}
+
+
+		public static void AutoFleetSave(Celestial celestial, bool isSleepTimeFleetSave = false, long minDuration = 0, bool forceUnsafe = false, bool WaitFleetsReturn = false, Missions TelegramMission = Missions.None, bool fromTelegram = false) {
 			DateTime departureTime = GetDateTime();
 			duration = minDuration;
 
@@ -1154,23 +1263,27 @@ namespace Tbot {
 				}
 			}
 
+			if (fromTelegram) {
+				celestial = TelegramGetCurrentCelestial();
+			}
 			celestial = UpdatePlanet(celestial, UpdateTypes.Ships);
 			if (celestial.Ships.GetMovableShips().IsEmpty()) {
 				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Skipping fleetsave from {celestial.ToString()}: there is no fleet to save!");
+				if (fromTelegram)
+					telegramMessenger.SendMessage($"{celestial.ToString()}: there is no fleet!");
 				return;
 			}
 
 			celestial = UpdatePlanet(celestial, UpdateTypes.Resources);
 			Celestial destination = new() { ID = 0 };
 			if (!forceUnsafe)
-				forceUnsafe = (bool) settings.SleepMode.AutoFleetSave.ForceUnsafe;
+				forceUnsafe = (bool) settings.SleepMode.AutoFleetSave.ForceUnsafe; //not used anymore
 
-			bool recall = false;
-			if ((bool) settings.SleepMode.AutoFleetSave.Recall)
-				recall = true;
 
 			if (celestial.Resources.Deuterium == 0) {
 				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Skipping fleetsave from {celestial.ToString()}: there is no fuel!");
+				if (fromTelegram)
+					telegramMessenger.SendMessage($"{celestial.ToString()}: there is no fuel!");
 				return;
 			}
 
@@ -1197,12 +1310,18 @@ namespace Tbot {
 			int fleetId = 0;
 			bool AlreadySent = false; //permit to swith to Harvest mission if not enough fuel to Deploy if celestial far away
 
-			Missions mission = Missions.Deploy;
+			//Doing DefaultMission or telegram /ghostto mission
+			Missions mission;
+			if (!Missions.TryParse(settings.SleepMode.AutoFleetSave.DefaultMission, out mission)) {
+				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, "Error: Could not parse 'DefaultMission' from settings, value set to Harvest.");
+				mission = Missions.Harvest;
+			}
+
 			if (TelegramMission != Missions.None)
 				mission = TelegramMission;
 
 			List<FleetHypotesis> fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
-			if (fleetHypotesis.Count() > 0) { 
+			if (fleetHypotesis.Count() > 0) {
 				foreach (FleetHypotesis fleet in fleetHypotesis.OrderBy(pf => pf.Fuel).ThenBy(pf => pf.Duration <= minDuration)) {
 					Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"checking {mission} fleet to: {fleet.Destination}");
 					if (CheckFuel(fleet, celestial)) {
@@ -1216,38 +1335,23 @@ namespace Tbot {
 					}
 				}
 			}
-			if (!AlreadySent) { 
-				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.ToString()} no Deploy possible doing Harvest..");
-				mission = Missions.Harvest;
+
+			//If /ghostto -> leaving function if failed
+			if (fromTelegram && !AlreadySent && mission == Missions.Harvest && fleetHypotesis.Count() == 0) {
+				telegramMessenger.SendMessage($"No debris field found for {mission}, try to /spycrash.");
+				return;
+			} else if (fromTelegram && !AlreadySent && fleetHypotesis.Count() >= 0) {
+				telegramMessenger.SendMessage($"Available fuel: {celestial.Resources.Deuterium}\nNo destination found for {mission}, try to reduce ghost time.");
+				return;
+			}
+
+			//Doing Deploy
+			if (!AlreadySent) {
+				if (mission == Missions.Harvest) { mission = Missions.Deploy; } else { mission = Missions.Harvest; };
+				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.ToString()} no Harvest possible, checking Deploy..");
+				mission = Missions.Deploy;
 				fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
-
-				if (fleetHypotesis.Count() == 0 && !forceUnsafe ) {
-					Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Skipping fleetsave from {celestial.ToString()} no Deploy or Harvest possible and forceUnsafe disabled!");
-
-				}
-				else {  //fleetHypotesis.Count() == 0 && forceUnsafe enabled
-					Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Skipping fleetsave from {celestial.ToString()} no Deploy or Harvest possible doing Unsafe..");
-					decimal speed = 100;
-					TelegramSwitch(speed, celestial);
-					/*
-					Need to modify this, going to 1,1,1 is bad, better Harvest near origin SS, Spy near origin SS, colonize near origin SS
-
-					if (fleetHypotesis.First().Destination.IsSame(new Coordinate(1, 1, 1, Celestials.Planet)) && celestial.Ships.Recycler > 0) {
-						mission = Missions.Harvest;
-						fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
-					}
-					if (fleetHypotesis.First().Destination.IsSame(new Coordinate(1, 1, 1, Celestials.Planet)) && celestial.Ships.EspionageProbe > 0) {
-						mission = Missions.Spy;
-						fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
-					}
-					if (fleetHypotesis.First().Destination.IsSame(new Coordinate(1, 1, 1, Celestials.Planet)) && celestial.Ships.ColonyShip > 0 && Helpers.CalcMaxPlanets(researches.Astrophysics) == celestials.Unique().Where(c => c.Coordinate.Type == Celestials.Planet).Count()) {
-						mission = Missions.Colonize;
-						fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
-					}
-					*/
-				}
-				if (fleetHypotesis.Count() > 0) {
-					Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"No destination found mission type changed to {mission}");
+				if (fleetHypotesis.Count > 0) {
 					foreach (FleetHypotesis fleet in fleetHypotesis.OrderBy(pf => pf.Fuel).ThenBy(pf => pf.Duration <= minDuration)) {
 						Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"checking {mission} fleet to: {fleet.Destination}");
 						if (CheckFuel(fleet, celestial)) {
@@ -1255,28 +1359,96 @@ namespace Tbot {
 
 							if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
 								possibleFleet = fleet;
+								AlreadySent = true;
 								break;
 							}
 						}
 					}
-				} else {
-					telegramMessenger.SendMessage($"Available fuel: {celestial.Resources.Deuterium}\nNo destination found, try to reduce ghost time.");
-					return;
+				}
+			}
+			//Doing colonize
+			if (!AlreadySent && celestial.Ships.ColonyShip > 0) {
+				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.ToString()} no Moon/Planet to switch on, checking Colonize destination...");
+				mission = Missions.Colonize;
+				fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
+				if (fleetHypotesis.Count > 0) {
+					foreach (FleetHypotesis fleet in fleetHypotesis.OrderBy(pf => pf.Fuel).ThenBy(pf => pf.Duration <= minDuration)) {
+						Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"checking {mission} fleet to: {fleet.Destination}");
+						if (CheckFuel(fleet, celestial)) {
+							fleetId = SendFleet(fleet.Origin, fleet.Ships, fleet.Destination, fleet.Mission, fleet.Speed, payload, userInfo.Class);
+
+							if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
+								possibleFleet = fleet;
+								AlreadySent = true;
+								break;
+							}
+						}
+					}
+				}
+			}
+			//Doing Spy
+			if (!AlreadySent && celestial.Ships.EspionageProbe > 0) {
+				mission = Missions.Spy;
+				fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
+				if (fleetHypotesis.Count > 0) {
+					foreach (FleetHypotesis fleet in fleetHypotesis.OrderBy(pf => pf.Fuel).ThenBy(pf => pf.Duration <= minDuration)) {
+						Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"checking {mission} fleet to: {fleet.Destination}");
+						if (CheckFuel(fleet, celestial)) {
+							fleetId = SendFleet(fleet.Origin, fleet.Ships, fleet.Destination, fleet.Mission, fleet.Speed, payload, userInfo.Class);
+
+							if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
+								possibleFleet = fleet;
+								AlreadySent = true;
+								break;
+							}
+						}
+					}
 				}
 			}
 
-			if (recall && fleetId != 0 || fleetId != -1 || fleetId != -2) {
-				Fleet fleet = fleets.Single(fleet => fleet.ID == fleetId);
-				DateTime time = GetDateTime();
-				var interval = ((minDuration / 2) * 1000) + Helpers.CalcRandomInterval(IntervalType.AMinuteOrTwo);
-				if (interval <= 0)
-					interval = Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
-				DateTime newTime = time.AddMilliseconds(interval);
-				timers.Add($"RecallTimer-{fleetId.ToString()}", new Timer(RetireFleet, fleet, interval, Timeout.Infinite));
-				Helpers.WriteLog(LogType.Info, LogSender.FleetScheduler, $"The fleet will be recalled at {newTime.ToString()}");
-				telegramMessenger.SendMessage($"Fleet {fleetId} send to {possibleFleet.Mission}, fuel consumed: {possibleFleet.Fuel.ToString("#,#", CultureInfo.InvariantCulture)}, recalled at {newTime.ToString()}");
+			//Doing switch
+			bool hasMoon = celestials.Count(c => c.HasCoords(new Coordinate(celestial.Coordinate.Galaxy, celestial.Coordinate.System, celestial.Coordinate.Position, Celestials.Moon))) == 1;
+			if (!AlreadySent && hasMoon) {
+				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.ToString()} no Deploy possible (missing fuel?), checking for switch if has Moon");
+				//var validSpeeds = userInfo.Class == CharacterClass.General ? Speeds.GetGeneralSpeedsList() : Speeds.GetNonGeneralSpeedsList();
+				//Random randomSpeed = new Random();
+				//decimal speed = validSpeeds[randomSpeed.Next(validSpeeds.Count)];
+				decimal speed = 100;
+				AlreadySent = TelegramSwitch(speed, celestial);
 			}
 
+			if (!AlreadySent) {
+				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.Coordinate.ToString()} no Moon/Planet to switch on, and Unsafe disabled, you gonna get hit!");
+				if ((bool) settings.TelegramMessenger.Active){
+					telegramMessenger.SendMessage($"Fleetsave from {celestial.Coordinate.ToString()} No destination found!, you gonna get hit!");
+				}
+				return;
+			}
+
+			
+			if ((bool) settings.SleepMode.AutoFleetSave.Recall && AlreadySent) {
+				if (fleetId != 0 && fleetId != -1 && fleetId != -2) {
+					Fleet fleet = fleets.Single(fleet => fleet.ID == fleetId);
+					DateTime time = GetDateTime();
+					var interval = ((minDuration / 2) * 1000) + Helpers.CalcRandomInterval(IntervalType.AMinuteOrTwo);
+					if (interval <= 0)
+						interval = Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+					DateTime newTime = time.AddMilliseconds(interval);
+					timers.Add($"RecallTimer-{fleetId.ToString()}", new Timer(RetireFleet, fleet, interval, Timeout.Infinite));
+					Helpers.WriteLog(LogType.Info, LogSender.FleetScheduler, $"The fleet will be recalled at {newTime.ToString()}");
+					if ((bool) settings.TelegramMessenger.Active || fromTelegram)
+						telegramMessenger.SendMessage($"Fleet {fleetId} send to {possibleFleet.Mission} on {possibleFleet.Destination.ToString()}, fuel consumed: {possibleFleet.Fuel.ToString("#,#", CultureInfo.InvariantCulture)}, recalled at {newTime.ToString()}");
+				}
+			}
+			else {
+				if (fleetId != 0 && fleetId != -1 && fleetId != -2) {
+					Fleet fleet = fleets.Single(fleet => fleet.ID == fleetId);
+					Helpers.WriteLog(LogType.Info, LogSender.FleetScheduler, $"Fleet {fleetId} send to {possibleFleet.Mission} on {possibleFleet.Destination.ToString()}, arrive at {possibleFleet.Duration} fuel consumed: {possibleFleet.Fuel.ToString("#,#", CultureInfo.InvariantCulture)}");
+					if ((bool) settings.TelegramMessenger.Active || fromTelegram)
+						telegramMessenger.SendMessage($"Fleet {fleetId} send to {possibleFleet.Mission} on {possibleFleet.Destination.ToString()}, arrive at {possibleFleet.Duration} fuel consumed: {possibleFleet.Fuel.ToString("#,#", CultureInfo.InvariantCulture)}");
+				}
+			}
+				
 		}
 
 		private static bool CheckFuel(FleetHypotesis fleetHypotesis, Celestial celestial) {
@@ -1319,80 +1491,69 @@ namespace Tbot {
 						}
 					}
 					break;
-				case Missions.Colonize:
-					for (int pos = 1; pos <= 15; pos++) {
-						if (pos == origin.Coordinate.Position)
-							continue;
-						galaxyInfo = ogamedService.GetGalaxyInfo(origin.Coordinate);
-						List<int> occupiedPos = new();
-						foreach (var planet in galaxyInfo.Planets) {
-							occupiedPos.Add(planet.Coordinate.Position);
-						}
-						if (occupiedPos.Any(op => op == pos))
-							continue;
-
-						possibleDestinations.Add(new(origin.Coordinate.Galaxy, origin.Coordinate.System, pos, Celestials.Planet));
+				case Missions.Colonize:					
+					galaxyInfo = ogamedService.GetGalaxyInfo(origin.Coordinate);
+					int pos = 1;
+					foreach (var planet in galaxyInfo.Planets) {
+						if (planet == null)
+							possibleDestinations.Add(new(origin.Coordinate.Galaxy, origin.Coordinate.System, pos));
+						pos =+ 1;
 					}
-					foreach (var possibleDestination in possibleDestinations) {
-						foreach (var currentSpeed in validSpeeds) {
-							FleetPrediction fleetPrediction = Helpers.CalcFleetPrediction(origin.Coordinate, possibleDestination, origin.Ships.GetMovableShips(), mission, currentSpeed, researches, serverData, userInfo.Class);
 
-							FleetHypotesis fleetHypotesis = new() {
-								Origin = origin,
-								Destination = possibleDestination,
-								Ships = origin.Ships.GetMovableShips(),
-								Mission = mission,
-								Speed = currentSpeed,
-								Duration = fleetPrediction.Time,
-								Fuel = fleetPrediction.Fuel
-							};
-							if (fleetHypotesis.Duration >= minFlightTime / 2 && fleetHypotesis.Fuel <= maxFuel) {
-								possibleFleets.Add(fleetHypotesis);
-								break;
-							}
-						}
-					}
-					break;
+					if (possibleDestinations.Count() > 0) {
+						foreach (var possibleDestination in possibleDestinations) {
+							foreach (var currentSpeed in validSpeeds) {
+								FleetPrediction fleetPrediction = Helpers.CalcFleetPrediction(origin.Coordinate, possibleDestination, origin.Ships.GetMovableShips(), mission, currentSpeed, researches, serverData, userInfo.Class);
 
-				case Missions.Harvest:
-					galaxyInfo = ogamedService.GetGalaxyInfo(origin.Coordinate.Galaxy, origin.Coordinate.System);
-					List<int> harvestablePos = new();
-					foreach (var planet in galaxyInfo.Planets ) {
-						if (planet != null && planet.Debris != null && planet.Debris.Resources.TotalResources > 0) {
-							possibleDestinations.Add(new(planet.Coordinate.Galaxy, planet.Coordinate.System, planet.Coordinate.Position, Celestials.Debris));
-						}		
-					}
-					
-					if (possibleDestinations.Count == 0) {
-						int sys = 0;
-						for ( sys = origin.Coordinate.System - 5 ; sys <= origin.Coordinate.System + 5; sys++) {
-							galaxyInfo = ogamedService.GetGalaxyInfo(origin.Coordinate.Galaxy, sys);
-							harvestablePos = new();
-							foreach (var planet in galaxyInfo.Planets) {
-								if (planet != null && planet.Debris != null && planet.Debris.Resources.TotalResources > 0) {
-									Console.WriteLine(planet.Debris.Resources.TotalResources);
-									possibleDestinations.Add(new(planet.Coordinate.Galaxy, planet.Coordinate.System, planet.Coordinate.Position, Celestials.Debris));
+								FleetHypotesis fleetHypotesis = new() {
+									Origin = origin,
+									Destination = possibleDestination,
+									Ships = origin.Ships.GetMovableShips(),
+									Mission = mission,
+									Speed = currentSpeed,
+									Duration = fleetPrediction.Time,
+									Fuel = fleetPrediction.Fuel
+								};
+								if (fleetHypotesis.Duration >= minFlightTime / 2 && fleetHypotesis.Fuel <= maxFuel) {
+									possibleFleets.Add(fleetHypotesis);
+									break;
 								}
 							}
 						}
 					}
+					break;
+				
+				case Missions.Harvest:
+					int playerid = userInfo.PlayerID;
+					int sys = 0;
+					for ( sys = origin.Coordinate.System - 5 ; sys <= origin.Coordinate.System + 5; sys++) {
+						galaxyInfo = ogamedService.GetGalaxyInfo(origin.Coordinate.Galaxy, sys);
+						foreach (var planet in galaxyInfo.Planets) {
+							if (planet != null && planet.Debris != null && planet.Debris.Resources.TotalResources > 0) {
+								possibleDestinations.Add(new(planet.Coordinate.Galaxy, planet.Coordinate.System, planet.Coordinate.Position, Celestials.Debris));
+							}
+						}
+					}
+					
+					
+					if (possibleDestinations.Count() > 0) {
+						foreach (var possibleDestination in possibleDestinations) {
+							foreach (var currentSpeed in validSpeeds) {
+								FleetPrediction fleetPrediction = Helpers.CalcFleetPrediction(origin.Coordinate, possibleDestination, origin.Ships.GetMovableShips(), mission, currentSpeed, researches, serverData, userInfo.Class);
 
-					foreach (var possibleDestination in possibleDestinations) {
-						foreach (var currentSpeed in validSpeeds) {
-							FleetPrediction fleetPrediction = Helpers.CalcFleetPrediction(origin.Coordinate, possibleDestination, origin.Ships.GetMovableShips(), mission, currentSpeed, researches, serverData, userInfo.Class);
-
-							FleetHypotesis fleetHypotesis = new() {
-								Origin = origin,
-								Destination = possibleDestination,
-								Ships = origin.Ships.GetMovableShips(),
-								Mission = mission,
-								Speed = currentSpeed,
-								Duration = fleetPrediction.Time,
-								Fuel = fleetPrediction.Fuel
-							};
-							if (fleetHypotesis.Duration >= minFlightTime / 2 && fleetHypotesis.Fuel <= maxFuel) {
-								possibleFleets.Add(fleetHypotesis);
-								break;
+								FleetHypotesis fleetHypotesis = new() {
+									Origin = origin,
+									Destination = possibleDestination,
+									Ships = origin.Ships.GetMovableShips(),
+									Mission = mission,
+									Speed = currentSpeed,
+									Duration = fleetPrediction.Time,
+									Fuel = fleetPrediction.Fuel
+								};
+								if (fleetHypotesis.Duration >= minFlightTime / 2 && fleetHypotesis.Fuel <= maxFuel) {
+									possibleFleets.Add(fleetHypotesis);
+									break;
+								}
 							}
 						}
 					}
@@ -1404,7 +1565,7 @@ namespace Tbot {
 						.Select(planet => planet.Coordinate)
 						.ToList();
 					
-					if (possibleDestinations.Count == 0 && forceUnsafe) {
+					if (possibleDestinations.Count == 0) {
 						possibleDestinations = celestials
 							.Where(planet => planet.ID != origin.ID)
 							.Select(planet => planet.Coordinate)
@@ -1434,28 +1595,11 @@ namespace Tbot {
 				default:
 					break;
 			}
-			if (possibleFleets.Count > 0) {
+			if (possibleFleets.Count() > 0) {
 				return possibleFleets;
 
 			} else {
 				return new List<FleetHypotesis>();
-				/*
-				if ( mission = Missions.Harvest ) {
-					mission = Missions.Transport;
-					FleetPrediction fleetPrediction = Helpers.CalcFleetPrediction(origin.Coordinate, new Coordinate(), origin.Ships.GetMovableShips(), mission, Speeds.TenPercent, researches, serverData, userInfo.Class);
-					FleetHypotesis fleetHypotesis = new() {
-						Origin = origin,
-						Destination = new Coordinate(),
-						Ships = origin.Ships.GetMovableShips(),
-						Mission = mission,
-						Speed = Speeds.TenPercent,
-						Duration = fleetPrediction.Time,
-						Fuel = fleetPrediction.Fuel
-					};
-					possibleFleets.Add(fleetHypotesis);
-				}
-				return possibleFleets;
-				*/
 			}
 		}
 		
@@ -1705,11 +1849,19 @@ namespace Tbot {
 			}
 		}
 
+
+		public static bool TelegramIsUnderAttack() {
+			bool result = ogamedService.IsUnderAttack();
+
+			return result;
+		}
+
+
 		public static void WakeUpNow(object state) {
 			if (timers.TryGetValue("TelegramSleepModeTimer", out Timer value))
 				value.Dispose();
-			timers.Remove("TelegramSleepModeTimer");
-			telegramMessenger.SendMessage($"[{userInfo.PlayerName} ({serverData.Name})] Bot woke up!");
+				timers.Remove("TelegramSleepModeTimer");
+				telegramMessenger.SendMessage($"[{userInfo.PlayerName} ({serverData.Name})] Bot woke up!");
 
 			Helpers.WriteLog(LogType.Info, LogSender.SleepMode, "Bot woke up!");
 
@@ -1739,6 +1891,30 @@ namespace Tbot {
 			}
 		}
 
+		private static void FakeActivity() {
+			//checking if under attack by making activity on planet/moon configured in settings (otherwise make acti on latest activated planet)
+			// And make activity on one more random planet to fake real player
+			Celestial celestial;
+			Celestial randomCelestial;
+			celestial = celestials
+				.Unique()
+				.Where(c => c.Coordinate.Galaxy == (int) settings.Brain.AutoMine.Transports.Origin.Galaxy)
+				.Where(c => c.Coordinate.System == (int) settings.Brain.AutoMine.Transports.Origin.System)
+				.Where(c => c.Coordinate.Position == (int) settings.Brain.AutoMine.Transports.Origin.Position)
+				.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) settings.Brain.AutoMine.Transports.Origin.Type))
+				.SingleOrDefault() ?? new() { ID = 0 };
+
+			Random random = new Random();
+			randomCelestial = celestials[random.Next(celestials.Count())];
+			ogamedService.GetDefences(randomCelestial);
+
+			if (celestial.ID != 0) {
+				ogamedService.GetDefences(celestial);
+			}
+
+			return;
+		}
+
 		private static void Defender(object state) {
 			try {
 				// Wait for the thread semaphore to avoid the concurrency with itself
@@ -1751,6 +1927,7 @@ namespace Tbot {
 					return;
 				}
 
+				FakeActivity();
 				fleets = UpdateFleets();
 				bool isUnderAttack = ogamedService.IsUnderAttack();
 				DateTime time = GetDateTime();
@@ -1768,7 +1945,7 @@ namespace Tbot {
 					Helpers.WriteLog(LogType.Info, LogSender.Defender, "Your empire is safe");
 				}
 				int interval = Helpers.CalcRandomInterval((int) settings.Defender.CheckIntervalMin, (int) settings.Defender.CheckIntervalMax);
-				if (interval <= 0)
+				if (interval <= 0)	
 					interval = Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
 				DateTime newTime = time.AddMilliseconds(interval);
 				timers.GetValueOrDefault("DefenderTimer").Change(interval, Timeout.Infinite);
@@ -2026,12 +2203,7 @@ namespace Tbot {
 						Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Delaying...");
 						var time = GetDateTime();
 						fleets = UpdateFleets();
-						long interval;
-						try {
-							interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
-						} catch {
-							interval = Helpers.CalcRandomInterval((int) settings.AutoResearch.CheckIntervalMin, (int) settings.AutoResearch.CheckIntervalMax);
-						}
+						long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
 						var newTime = time.AddMilliseconds(interval);
 						timers.GetValueOrDefault("AutoResearchTimer").Change(interval, Timeout.Infinite);
 						Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Next AutoResearch check at {newTime.ToString()}");
@@ -3081,20 +3253,15 @@ namespace Tbot {
 					Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Stopping AutoMine check for {celestial.ToString()}.");
 					if (timers.TryGetValue($"AutoMineTimer-{celestial.ID.ToString()}", out Timer value))
 						value.Dispose();
-					timers.Remove(autoMineTimer);
+						timers.Remove(autoMineTimer);
 				} else if (delay) {
 					Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Delaying...");
 					time = GetDateTime();
 					fleets = UpdateFleets();
-					long interval;
-					try {
-						interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
-					} catch {
-						interval = Helpers.CalcRandomInterval((int) settings.AutoMine.CheckIntervalMin, (int) settings.AutoMine.CheckIntervalMax);
-					}
+					long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
 					if (timers.TryGetValue(autoMineTimer, out Timer value))
 						value.Dispose();
-					timers.Remove(autoMineTimer);
+						timers.Remove(autoMineTimer);
 					newTime = time.AddMilliseconds(interval);
 					timers.Add(autoMineTimer, new Timer(AutoMine, celestial, interval, Timeout.Infinite));
 					Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Next AutoMine check for {celestial.ToString()} at {newTime.ToString()}");
@@ -3105,7 +3272,7 @@ namespace Tbot {
 
 					if (timers.TryGetValue(autoMineTimer, out Timer value))
 						value.Dispose();
-					timers.Remove(autoMineTimer);
+						timers.Remove(autoMineTimer);
 
 					newTime = time.AddMilliseconds(interval);
 					timers.Add(autoMineTimer, new Timer(AutoMine, celestial, interval, Timeout.Infinite));
@@ -3589,12 +3756,7 @@ namespace Tbot {
 						Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Delaying...");						
 						fleets = UpdateFleets();
 						var time = GetDateTime();
-						long interval;
-						try {
-							interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
-						} catch {
-							interval = Helpers.CalcRandomInterval((int) settings.AutoRepatriate.CheckIntervalMin, (int) settings.AutoRepatriate.CheckIntervalMax);
-						}
+						long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
 						var newTime = time.AddMilliseconds(interval);
 						timers.GetValueOrDefault("RepatriateTimer").Change(interval, Timeout.Infinite);
 						Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Next repatriate check at {newTime.ToString()}");
@@ -3647,6 +3809,7 @@ namespace Tbot {
 					speed == Speeds.NinetyfivePercent
 				)
 			) {*/
+
 			if (!Helpers.GetValidSpeedsForClass(playerClass).Any(s => s == speed)) {
 				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, "Unable to send fleet: speed not available for your class");
 				return 0;
@@ -3781,9 +3944,13 @@ namespace Tbot {
 
 		public static void TelegramMesgAttacker(string message) {
 			attacks = ogamedService.GetAttacks();
+			List<int> playerid = new List<int>();
+
 			foreach (AttackerFleet attack in attacks) {
-				if (attack.AttackerID != 0) {
+				if (attack.AttackerID != 0 && !playerid.Any(s => s == attack.AttackerID)) {
 					var result = ogamedService.SendMessage(attack.AttackerID, message);
+					playerid.Add(attack.AttackerID);
+
 					if (result)
 						telegramMessenger.SendMessage($"Message succesfully sent to {attack.AttackerName}.");
 					else
@@ -3929,7 +4096,7 @@ namespace Tbot {
 					return;
 				}
 
-				if ((bool) settings.Expeditions.Active) {
+				if ((bool) settings.Expeditions.Active || timers.TryGetValue("ExpeditionsTimer", out Timer value)) {
 					researches = UpdateResearches();
 					if (researches.Astrophysics == 0) {
 						Helpers.WriteLog(LogType.Info, LogSender.Expeditions, "Skipping: Astrophysics not yet researched!");
@@ -4198,12 +4365,7 @@ namespace Tbot {
 						Helpers.WriteLog(LogType.Info, LogSender.Expeditions, $"Delaying...");
 						var time = GetDateTime();
 						fleets = UpdateFleets();
-						long interval;
-						try {
-							interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
-						} catch {
-							interval = Helpers.CalcRandomInterval((int) settings.Expeditions.CheckIntervalMin, (int) settings.Expeditions.CheckIntervalMax);
-						}
+						long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
 						var newTime = time.AddMilliseconds(interval);
 						timers.GetValueOrDefault("ExpeditionsTimer").Change(interval, Timeout.Infinite);
 						Helpers.WriteLog(LogType.Info, LogSender.Expeditions, $"Next check at {newTime.ToString()}");
@@ -4385,12 +4547,7 @@ namespace Tbot {
 						Helpers.WriteLog(LogType.Info, LogSender.Harvest, $"Delaying...");
 						var time = GetDateTime();
 						fleets = UpdateFleets();
-						long interval;
-						try {
-							interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
-						} catch {
-							interval = Helpers.CalcRandomInterval((int) settings.AutoHarvest.CheckIntervalMin, (int) settings.AutoHarvest.CheckIntervalMax);
-						}
+						long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
 						var newTime = time.AddMilliseconds(interval);
 						timers.GetValueOrDefault("HarvestTimer").Change(interval, Timeout.Infinite);
 						Helpers.WriteLog(LogType.Info, LogSender.Harvest, $"Next check at {newTime.ToString()}");
@@ -4558,13 +4715,7 @@ namespace Tbot {
 						Helpers.WriteLog(LogType.Info, LogSender.Colonize, $"Delaying...");
 						var time = GetDateTime();
 						fleets = UpdateFleets();
-						long interval;
-						try {
-							interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
-						}
-						catch {
-							interval = Helpers.CalcRandomInterval((int) settings.AutoColonize.CheckIntervalMin, (int) settings.AutoColonize.CheckIntervalMax);
-						}
+						long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
 						var newTime = time.AddMilliseconds(interval);
 						timers.GetValueOrDefault("ColonizeTimer").Change(interval, Timeout.Infinite);
 						Helpers.WriteLog(LogType.Info, LogSender.Colonize, $"Next check at {newTime}");

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -21,7 +21,7 @@ namespace Tbot {
 		static volatile Server serverInfo;
 		static volatile ServerData serverData;
 		static volatile UserInfo userInfo;
-		public static volatile List<Celestial> celestials;
+		static volatile List<Celestial> celestials;
 		static volatile List<Fleet> fleets;
 		static volatile List<AttackerFleet> attacks;
 		static volatile Slots slots;
@@ -36,14 +36,13 @@ namespace Tbot {
 		static Dictionary<Feature, Semaphore> xaSem = new();
 		static long duration;
 		static DateTime NextWakeUpTime;
-		public static volatile Celestial TelegramCurrentCelestial;
+		public static volatile Celestial CurrentMainCelestial;
 
 		static void Main(string[] args) {
 			Helpers.SetTitle();
 			isSleeping = false;
 
 			ReadSettings();
-
 			PhysicalFileProvider physicalFileProvider = new(Path.GetFullPath(AppContext.BaseDirectory));
 			var changeToken = physicalFileProvider.Watch("settings.json");
 			changeToken.RegisterChangeCallback(OnSettingsChanged, default);
@@ -172,9 +171,8 @@ namespace Tbot {
 					xaSem[Feature.Expeditions] = new Semaphore(1, 1);
 					xaSem[Feature.Harvest] = new Semaphore(1, 1);
 					xaSem[Feature.Colonize] = new Semaphore(1, 1);
-					xaSem[Feature.FleetScheduler] = new Semaphore(1, 1);
+					xaSem[Feature.FleetScheduler] = new Semaphore(1, 3);
 					xaSem[Feature.SleepMode] = new Semaphore(1, 1);
-					xaSem[Feature.TelegramAutoPong] = new Semaphore(1, 1);
 
 					features = new();
 					features.AddOrUpdate(Feature.Defender, false, HandleStartStopFeatures);
@@ -190,7 +188,6 @@ namespace Tbot {
 					features.AddOrUpdate(Feature.Harvest, false, HandleStartStopFeatures);
 					features.AddOrUpdate(Feature.FleetScheduler, false, HandleStartStopFeatures);
 					features.AddOrUpdate(Feature.SleepMode, false, HandleStartStopFeatures);
-					features.AddOrUpdate(Feature.TelegramAutoPong, false, HandleStartStopFeatures);
 
 					Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Initializing data...");
 					celestials = GetPlanets();
@@ -286,11 +283,6 @@ namespace Tbot {
 						if (!currentValue)
 							InitializeSleepMode();
 						return true;
-					case Feature.TelegramAutoPong:
-						if (currentValue)
-							StopTelegramAutoPong();
-						return false;
-						
 					default:
 						return false;
 				}
@@ -408,15 +400,6 @@ namespace Tbot {
 							StopSleepMode();
 						return false;
 					}
-				case Feature.TelegramAutoPong:
-					if ((bool) settings.TelegramMessenger.TelegramAutoPong.Active) {
-						InitializeTelegramAutoPong();
-						return true;
-					} else {
-						if (currentValue)
-							StopTelegramAutoPong();
-						return false;
-					}
 				default:
 					return false;
 			}
@@ -435,58 +418,54 @@ namespace Tbot {
 			features.AddOrUpdate(Feature.Expeditions, false, HandleStartStopFeatures);
 			features.AddOrUpdate(Feature.Harvest, false, HandleStartStopFeatures);
 			features.AddOrUpdate(Feature.Colonize, false, HandleStartStopFeatures);
-			features.AddOrUpdate(Feature.TelegramAutoPong, false, HandleStartStopFeatures);
 		}
 
 		private static void ReadSettings() {
 			settings = SettingsService.GetSettings();
 		}
 
-		public static bool EditSettings(Celestial celestial = null, string recall = "") {
+		private static void WriteSetting(Celestial celestial) {
+			string type = "";
+			if (celestial.Coordinate.Type == Celestials.Moon)
+				type = "Moon" ?? "Planet";
+
 			System.Threading.Thread.Sleep(500);
 			var file = File.ReadAllText($"{Path.GetFullPath(AppContext.BaseDirectory)}/settings.json");
 			var jsonObj = new JObject();
 			jsonObj = Newtonsoft.Json.JsonConvert.DeserializeObject<dynamic>(file);
 
-			if (recall != "") {
-				jsonObj["SleepMode"]["AutoFleetSave"]["Recall"] = Convert.ToBoolean(recall);
-			}
+			jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
+			jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["System"] = (int) celestial.Coordinate.System;
+			jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["Position"] = (int) celestial.Coordinate.Position;
+			jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["Type"] = type;
 
-			if (celestial != null) {
-				string type = "";
-				if (celestial.Coordinate.Type == Celestials.Moon)
-					type = "Moon" ?? "Planet";
+			jsonObj["Brain"]["AutoResearch"]["Target"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
+			jsonObj["Brain"]["AutoResearch"]["Target"]["System"] = (int) celestial.Coordinate.System;
+			jsonObj["Brain"]["AutoResearch"]["Target"]["Position"] = (int) celestial.Coordinate.Position;
+			jsonObj["Brain"]["AutoResearch"]["Target"]["Type"] = (int) Celestials.Planet;
 
-				jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
-				jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["System"] = (int) celestial.Coordinate.System;
-				jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["Position"] = (int) celestial.Coordinate.Position;
-				jsonObj["Brain"]["AutoMine"]["Transports"]["Origin"]["Type"] = type;
+			jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
+			jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["System"] = (int) celestial.Coordinate.System;
+			jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["Position"] = (int) celestial.Coordinate.Position;
+			jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["Type"] = type;
 
-				jsonObj["Brain"]["AutoResearch"]["Target"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
-				jsonObj["Brain"]["AutoResearch"]["Target"]["System"] = (int) celestial.Coordinate.System;
-				jsonObj["Brain"]["AutoResearch"]["Target"]["Position"] = (int) celestial.Coordinate.Position;
-				jsonObj["Brain"]["AutoResearch"]["Target"]["Type"] = "Planet";
+			jsonObj["Brain"]["AutoRepatriate"]["Target"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
+			jsonObj["Brain"]["AutoRepatriate"]["Target"]["System"] = (int) celestial.Coordinate.System;
+			jsonObj["Brain"]["AutoRepatriate"]["Target"]["Position"] = (int) celestial.Coordinate.Position;
+			jsonObj["Brain"]["AutoRepatriate"]["Target"]["Type"] = type;
 
-				jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
-				jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["System"] = (int) celestial.Coordinate.System;
-				jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["Position"] = (int) celestial.Coordinate.Position;
-				jsonObj["Brain"]["AutoResearch"]["Transports"]["Origin"]["Type"] = type;
-
-				jsonObj["Brain"]["AutoRepatriate"]["Target"]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
-				jsonObj["Brain"]["AutoRepatriate"]["Target"]["System"] = (int) celestial.Coordinate.System;
-				jsonObj["Brain"]["AutoRepatriate"]["Target"]["Position"] = (int) celestial.Coordinate.Position;
-				jsonObj["Brain"]["AutoRepatriate"]["Target"]["Type"] = type;
-
-				jsonObj["Expeditions"]["Origin"][0]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
-				jsonObj["Expeditions"]["Origin"][0]["System"] = (int) celestial.Coordinate.System;
-				jsonObj["Expeditions"]["Origin"][0]["Position"] = (int) celestial.Coordinate.Position;
-				jsonObj["Expeditions"]["Origin"][0]["Type"] = type;
-			}
+			jsonObj["Expeditions"]["Origin"][0]["Galaxy"] = (int) celestial.Coordinate.Galaxy;
+			jsonObj["Expeditions"]["Origin"][0]["System"] = (int) celestial.Coordinate.System;
+			jsonObj["Expeditions"]["Origin"][0]["Position"] = (int) celestial.Coordinate.Position;
+			jsonObj["Expeditions"]["Origin"][0]["Type"] = type;
 
 			string output = Newtonsoft.Json.JsonConvert.SerializeObject(jsonObj, Newtonsoft.Json.Formatting.Indented);
 			File.WriteAllText($"{Path.GetFullPath(AppContext.BaseDirectory)}/settings.json", output);
 
-			return true;
+		}
+
+		private static void WriteSetting() {
+			settings = SettingsService.GetSettings();
 		}
 
 		public static void WaitFeature() {
@@ -515,8 +494,7 @@ namespace Tbot {
 			xaSem[Feature.SleepMode].WaitOne();
 		}
 
-		private static void OnSettingsChanged(object state) {
-
+		private static void OnSettingsChanged(object sender) {
 			xaSem[Feature.Defender].WaitOne();
 			xaSem[Feature.Brain].WaitOne();
 			xaSem[Feature.Expeditions].WaitOne();
@@ -524,7 +502,6 @@ namespace Tbot {
 			xaSem[Feature.Colonize].WaitOne();
 			xaSem[Feature.AutoFarm].WaitOne();
 			xaSem[Feature.SleepMode].WaitOne();
-			xaSem[Feature.TelegramAutoPong].WaitOne();
 
 			Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Settings file changed");
 			ReadSettings();
@@ -536,7 +513,6 @@ namespace Tbot {
 			xaSem[Feature.Colonize].Release();
 			xaSem[Feature.AutoFarm].Release();
 			xaSem[Feature.SleepMode].Release();
-			xaSem[Feature.TelegramAutoPong].Release();
 
 			InitializeSleepMode();
 			UpdateTitle();
@@ -842,40 +818,18 @@ namespace Tbot {
 			}
 		}
 
-		public static void InitializeTelegramAutoPong() {
-			DateTime now = GetDateTime();
-			long everyHours = 0;
-			if ((bool) settings.TelegramMessenger.TelegramAutoPong.Active) {
-				everyHours = settings.TelegramMessenger.TelegramAutoPong.EveryHours;
-			}
-			DateTime roundedNextHour = now.AddHours(everyHours).AddMinutes(-now.Minute).AddSeconds(-now.Second);
-			long nextpong = (long) roundedNextHour.Subtract(now).TotalMilliseconds;
-			
-			Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Initializing TelegramAutoPong...");
-			StopTelegramAutoPong(false);
-			timers.Add("TelegramAutoPong", new Timer(TelegramAutoPong, null, nextpong, Timeout.Infinite));
-		}
-
-		public static void StopTelegramAutoPong(bool echo = true) {
-			if (echo)
-				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping TelegramAutoPong...");
-			if (timers.TryGetValue("TelegramAutoPong", out Timer value))
-				value.Dispose();
-				timers.Remove("TelegramAutoPong");
-		}
-
-		public static void InitializeDefender() {
+		private static void InitializeDefender() {
 			Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Initializing defender...");
 			StopDefender(false);
 			timers.Add("DefenderTimer", new Timer(Defender, null, Helpers.CalcRandomInterval(IntervalType.AFewSeconds), Timeout.Infinite));
 		}
 
-		public static void StopDefender(bool echo = true) {
+		private static void StopDefender(bool echo = true) {
 			if (echo)
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping defender...");
 			if (timers.TryGetValue("DefenderTimer", out Timer value))
 				value.Dispose();
-				timers.Remove("DefenderTimer");
+			timers.Remove("DefenderTimer");
 		}
 
 		private static void InitializeBrainAutoCargo() {
@@ -889,7 +843,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping autocargo...");
 			if (timers.TryGetValue("CapacityTimer", out Timer value))
 				value.Dispose();
-				timers.Remove("CapacityTimer");
+			timers.Remove("CapacityTimer");
 		}
 
 		public static void InitializeBrainRepatriate() {
@@ -903,7 +857,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping repatriate...");
 			if (timers.TryGetValue("RepatriateTimer", out Timer value))
 				value.Dispose();
-				timers.Remove("RepatriateTimer");
+			timers.Remove("RepatriateTimer");
 		}
 
 		public static void InitializeBrainAutoMine() {
@@ -921,7 +875,7 @@ namespace Tbot {
 			foreach (var celestial in celestials) {
 				if (timers.TryGetValue($"AutoMineTimer-{celestial.ID.ToString()}", out value))
 					value.Dispose();
-					timers.Remove($"AutoMineTimer-{celestial.ID.ToString()}");
+				timers.Remove($"AutoMineTimer-{celestial.ID.ToString()}");
 			}
 		}
 
@@ -936,7 +890,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping offer of the day...");
 			if (timers.TryGetValue("OfferOfTheDayTimer", out Timer value))
 				value.Dispose();
-				timers.Remove("OfferOfTheDayTimer");
+			timers.Remove("OfferOfTheDayTimer");
 		}
 
 		private static void InitializeBrainAutoResearch() {
@@ -950,7 +904,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping autoresearch...");
 			if (timers.TryGetValue("AutoResearchTimer", out Timer value))
 				value.Dispose();
-				timers.Remove("AutoResearchTimer");
+			timers.Remove("AutoResearchTimer");
 		}
 
 		private static void InitializeAutoFarm() {
@@ -964,7 +918,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping autofarm...");
 			if (timers.TryGetValue("AutoFarmTimer", out Timer value))
 				value.Dispose();
-				timers.Remove("AutoFarmTimer");
+			timers.Remove("AutoFarmTimer");
 		}
 
 		public static void InitializeExpeditions() {
@@ -978,7 +932,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping expeditions...");
 			if (timers.TryGetValue("ExpeditionsTimer", out Timer value))
 				value.Dispose();
-				timers.Remove("ExpeditionsTimer");
+			timers.Remove("ExpeditionsTimer");
 		}
 
 		private static void InitializeHarvest() {
@@ -992,7 +946,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping harvest...");
 			if (timers.TryGetValue("HarvestTimer", out Timer value))
 				value.Dispose();
-				timers.Remove("HarvestTimer");
+			timers.Remove("HarvestTimer");
 		}
 
 		private static void InitializeColonize() {
@@ -1006,7 +960,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping colonize...");
 			if (timers.TryGetValue("ColonizeTimer", out Timer value))
 				value.Dispose();
-				timers.Remove("ColonizeTimer");
+			timers.Remove("ColonizeTimer");
 		}
 
 		private static void InitializeSleepMode() {
@@ -1020,7 +974,7 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping sleep mode...");
 			if (timers.TryGetValue("SleepModeTimer", out Timer value))
 				value.Dispose();
-				timers.Remove("SleepModeTimer");
+			timers.Remove("SleepModeTimer");
 		}
 		
 		private static void InitializeFleetScheduler() {
@@ -1035,37 +989,47 @@ namespace Tbot {
 				Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Stopping fleet scheduler...");
 			if (timers.TryGetValue("FleetSchedulerTimer", out Timer value))
 				value.Dispose();
-				timers.Remove("FleetSchedulerTimer");
+			timers.Remove("FleetSchedulerTimer");
 		}
 
+		public static void TelegramCelestial(Coordinate coord, string type, bool editsettings = false) {
+			celestials = UpdateCelestials();
 
-		public static void TelegramAutoPong(object state) {
-			xaSem[Feature.TelegramAutoPong].WaitOne();
-			DateTime time = GetDateTime();
-			DateTime newTime = time.AddMilliseconds(3600000);
-			timers.GetValueOrDefault("TelegramAutoPong").Change(3600000, Timeout.Infinite);
-			Helpers.WriteLog(LogType.Info, LogSender.Telegram, $"Next check at {newTime.ToString()}");
-			telegramMessenger.SendMessage("[TBot] Alive");
-			xaSem[Feature.TelegramAutoPong].Release();
+			CurrentMainCelestial = celestials
+				.Unique()
+				.Where(c => c.Coordinate.Galaxy == (int) coord.Galaxy)
+				.Where(c => c.Coordinate.System == (int) coord.System)
+				.Where(c => c.Coordinate.Position == (int) coord.Position)
+				.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>(type))
+				.SingleOrDefault() ?? new() { ID = 0 };
 
+			if (CurrentMainCelestial.ID == 0) {
+				telegramMessenger.SendMessage("Error! Could not update main celestial with wrong information. Verify coordinate.");
+				return;
+			}
+			if (editsettings) {
+				WriteSetting(CurrentMainCelestial);
+				telegramMessenger.SendMessage($"JSON settings updated to: {CurrentMainCelestial.Coordinate.ToString()}");
+			} else {
+				telegramMessenger.SendMessage($"Main celestial successfuly updated to {CurrentMainCelestial.Coordinate.ToString()}");
+			}
 			return;
 		}
 
-		public static bool TelegramSwitch(decimal speed, Celestial attacked = null, bool fromTelegram = false) {
+		public static void TelegramSwitch(decimal speed, Celestial attacked = null) {
 			Celestial celestial;
 
 			if (attacked == null) {
-				celestial = TelegramGetCurrentCelestial();	
+				celestial = TelegramGetMainCelestial();	
 			} else {
-				celestial = attacked; //for autofleetsave func when under attack, last option if no other destination found.
+				celestial = attacked;
 			}
 
 			if ( celestial.Coordinate.Type == Celestials.Planet) {
 				bool hasMoon = celestials.Count(c => c.HasCoords(new Coordinate(celestial.Coordinate.Galaxy, celestial.Coordinate.System, celestial.Coordinate.Position, Celestials.Moon))) == 1;
 				if (!hasMoon) {
-					if ((bool) settings.TelegramMessenger.Active || fromTelegram)
-						telegramMessenger.SendMessage($"This planet does not have a Moon! Switch impossible.");
-					return false;
+					telegramMessenger.SendMessage($"This planet does not have a Moon dumbass!");
+					return;
 				}
 			}
 			
@@ -1084,81 +1048,60 @@ namespace Tbot {
 			celestial = UpdatePlanet(celestial, UpdateTypes.Ships);
 
 			if (celestial.Ships.GetMovableShips().IsEmpty()) {
-				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"[Switch] Skipping fleetsave from {celestial.Coordinate.ToString()}: No ships!");
-				if ((bool) settings.TelegramMessenger.Active || fromTelegram)
-					telegramMessenger.SendMessage($"No ships on {celestial.Coordinate}, did you /celestial?");
-				return false;
+				telegramMessenger.SendMessage($"No ships on {celestial.Coordinate}, did you /celestial?");
+				return;
 			}
 
 			var payload = celestial.Resources;
 			if (celestial.Resources.Deuterium == 0) {
-				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"[Switch] Skipping fleetsave from { celestial.Coordinate.ToString()}: there is no fuel!");
-				if ((bool) settings.TelegramMessenger.Active || fromTelegram)
-					telegramMessenger.SendMessage($"Skipping fleetsave from {celestial.Coordinate.ToString()}: there is no fuel!");
-				return false;
+				telegramMessenger.SendMessage($"Skipping fleetsave from {celestial.Coordinate.ToString()}: there is no fuel!");
+				return;
 			}
 
 			FleetPrediction fleetPrediction = Helpers.CalcFleetPrediction(celestial.Coordinate, dest, celestial.Ships, Missions.Deploy, speed, researches, serverData, userInfo.Class);
 			int fleetId = SendFleet(celestial, celestial.Ships, dest, Missions.Deploy, speed, payload, userInfo.Class, true);
 
 			if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
-				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleet {fleetId} switched from {celestial.Coordinate.Type} to {dest.Type}\nPredicted time: {TimeSpan.FromSeconds(fleetPrediction.Time).ToString()}");
-				if ((bool) settings.TelegramMessenger.Active || fromTelegram)
-					telegramMessenger.SendMessage($"Fleet {fleetId} switched from {celestial.Coordinate.Type} to {dest.Type}\nPredicted time: {TimeSpan.FromSeconds(fleetPrediction.Time).ToString()}");
-				return true;
+				telegramMessenger.SendMessage($"Fleet {fleetId} switched from {celestial.Coordinate.Type} to {dest.Type}\nPredicted time: {TimeSpan.FromSeconds(fleetPrediction.Time).ToString()}");
 			}
-
-			return false;
-		}
-
-		public static void TelegramSetCurrentCelestial(Coordinate coord, string type, bool editsettings = false) {
-			celestials = UpdateCelestials();
-
-			//check if no error in submitted celestial (belongs to the current player)
-			TelegramCurrentCelestial = celestials
-				.Unique()
-				.Where(c => c.Coordinate.Galaxy == (int) coord.Galaxy)
-				.Where(c => c.Coordinate.System == (int) coord.System)
-				.Where(c => c.Coordinate.Position == (int) coord.Position)
-				.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>(type))
-				.SingleOrDefault() ?? new() { ID = 0 };
-
-			if (TelegramCurrentCelestial.ID == 0) {
-				telegramMessenger.SendMessage("Error! Wrong information. Verify coordinate.\n");
-				return;
-			}
-			if (editsettings) {
-				EditSettings(TelegramCurrentCelestial);
-				telegramMessenger.SendMessage($"JSON settings updated to: {TelegramCurrentCelestial.Coordinate.ToString()}\nWait few seconds for Bot to reload before sending commands.");
-			} else {
-				telegramMessenger.SendMessage($"Main celestial successfuly updated to {TelegramCurrentCelestial.Coordinate.ToString()}");
+			else {
+				Helpers.WriteLog(LogType.Info, LogSender.FleetScheduler, $"Telegram switch failed to sent on {dest.ToString()}");
+				telegramMessenger.SendMessage($"Telegram switch failed to sent on {dest.ToString()}");
 			}
 			return;
 		}
 
-		public static Celestial TelegramGetCurrentCelestial() {
-			if (TelegramCurrentCelestial == null) {
-				Celestial celestial;
-				celestial = celestials
-					.Unique()
-					.Where(c => c.Coordinate.Galaxy == (int) settings.Brain.AutoMine.Transports.Origin.Galaxy)
-					.Where(c => c.Coordinate.System == (int) settings.Brain.AutoMine.Transports.Origin.System)
-					.Where(c => c.Coordinate.Position == (int) settings.Brain.AutoMine.Transports.Origin.Position)
-					.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) settings.Brain.AutoMine.Transports.Origin.Type))
-					.SingleOrDefault() ?? new() { ID = 0 };
+		private static Celestial TelegramGetMainCelestial() {
+			celestials = UpdateCelestials();
+			Celestial celestial;
+			celestial = celestials
+				.Unique()
+				.Where(c => c.Coordinate.Galaxy == (int) settings.Brain.AutoMine.Transports.Origin.Galaxy)
+				.Where(c => c.Coordinate.System == (int) settings.Brain.AutoMine.Transports.Origin.System)
+				.Where(c => c.Coordinate.Position == (int) settings.Brain.AutoMine.Transports.Origin.Position)
+				.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) settings.Brain.AutoMine.Transports.Origin.Type))
+				.SingleOrDefault() ?? new() { ID = 0 };
 
-				if (celestial.ID == 0) {
-					telegramMessenger.SendMessage("Error! Could not parse Celestial from JSON settings (Need /editsettings)");
-					return new Celestial();
-				}
-
-				TelegramCurrentCelestial = celestial;
+			if (celestial.ID == 0) {
+				telegramMessenger.SendMessage("Error! Could not parse Celestial from JSON settings.");
+				return new Celestial();
 			}
 
-			return TelegramCurrentCelestial;
+			if (CurrentMainCelestial == null) 
+				CurrentMainCelestial = celestial;
+
+			string check = celestial.Coordinate.ToString();
+			if (!check.Equals(CurrentMainCelestial.Coordinate.ToString())) {
+				telegramMessenger.SendMessage($"JSON data:{celestial.Coordinate.ToString()}\nCarefull, Your program current Main Celestial differ from the local settings one. Modify your JSON file (AutoMine.Transports) or /editsettings.");
+				celestial = CurrentMainCelestial;
+			}
+
+			return celestial;
 		}
 
-		public static void TelegramGetInfo(Celestial celestial) {
+		public static void TelegramGetInfo() {
+			Celestial celestial = TelegramGetMainCelestial();
+			if (celestial == null) { telegramMessenger.SendMessage($"Could not get Celestial, did you /update?"); return; }
 
 			celestial = UpdatePlanet(celestial, UpdateTypes.Resources);
 			celestial = UpdatePlanet(celestial, UpdateTypes.Ships);
@@ -1180,59 +1123,7 @@ namespace Tbot {
 			return;
 		}
 
-
-		public static void SpyCrash(Celestial fromCelestial, Coordinate target = null) {
-			decimal speed = Speeds.HundredPercent;
-			fromCelestial = UpdatePlanet(fromCelestial, UpdateTypes.Ships);
-			var payload = fromCelestial.Resources;
-			Random random = new Random();
-
-			if (fromCelestial.Ships.EspionageProbe == 0 || payload.Deuterium < 1) {
-				Helpers.WriteLog(LogType.Info, LogSender.FleetScheduler, $"No probes or no Fuel on {fromCelestial.Coordinate.ToString()}!");
-				telegramMessenger.SendMessage($"No probes or no Fuel on {fromCelestial.Coordinate.ToString()}!");
-				return;
-			}
-			// spycrash auto part
-			if (target == null) {
-				List<Coordinate> spycrash = new();
-				int playerid = userInfo.PlayerID;
-				int sys = 0;
-				for ( sys = fromCelestial.Coordinate.System - 2 ; sys <= fromCelestial.Coordinate.System + 2; sys++) {
-					GalaxyInfo galaxyInfo = ogamedService.GetGalaxyInfo(fromCelestial.Coordinate.Galaxy, sys);
-					foreach (var planet in galaxyInfo.Planets) {
-						try {
-							if (planet != null && !planet.Administrator && !planet.Inactive && !planet.StrongPlayer && !planet.Newbie && !planet.Banned && !planet.Vacation) {
-								if (planet.Player.ID != playerid) { //exclude player planet
-									spycrash.Add(new(planet.Coordinate.Galaxy, planet.Coordinate.System, planet.Coordinate.Position, Celestials.Planet));
-								}
-							}
-						} catch (NullReferenceException) {
-							continue;
-						}
-					}
-				}
-
-				if (spycrash.Count() == 0) {
-					telegramMessenger.SendMessage($"No planet to spycrash on could be found (over system -2 -> +2)");
-					return;
-				} else {
-					target = spycrash[random.Next(spycrash.Count())];
-				}
-			}
-			var attackingShips = new Ships().Add(Buildables.EspionageProbe, 1);
-
-			int fleetId = SendFleet(fromCelestial, attackingShips, target, Missions.Attack, speed);
-
-			if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
-				Helpers.WriteLog(LogType.Info, LogSender.FleetScheduler, $"EspionageProbe sent to crash on {target.ToString()}");
-
-				telegramMessenger.SendMessage($"EspionageProbe sent to crash on {target.ToString()}");
-			}
-			return;
-		}
-
-
-		public static void AutoFleetSave(Celestial celestial, bool isSleepTimeFleetSave = false, long minDuration = 0, bool forceUnsafe = false, bool WaitFleetsReturn = false, Missions TelegramMission = Missions.None, bool fromTelegram = false) {
+		public static void AutoFleetSave(Celestial celestial, bool isSleepTimeFleetSave = false, long minDuration = 0, bool forceUnsafe = false, bool WaitFleetsReturn = false, Missions TelegramMission = Missions.None) {
 			DateTime departureTime = GetDateTime();
 			duration = minDuration;
 
@@ -1263,27 +1154,23 @@ namespace Tbot {
 				}
 			}
 
-			if (fromTelegram) {
-				celestial = TelegramGetCurrentCelestial();
-			}
 			celestial = UpdatePlanet(celestial, UpdateTypes.Ships);
 			if (celestial.Ships.GetMovableShips().IsEmpty()) {
 				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Skipping fleetsave from {celestial.ToString()}: there is no fleet to save!");
-				if (fromTelegram)
-					telegramMessenger.SendMessage($"{celestial.ToString()}: there is no fleet!");
 				return;
 			}
 
 			celestial = UpdatePlanet(celestial, UpdateTypes.Resources);
 			Celestial destination = new() { ID = 0 };
 			if (!forceUnsafe)
-				forceUnsafe = (bool) settings.SleepMode.AutoFleetSave.ForceUnsafe; //not used anymore
+				forceUnsafe = (bool) settings.SleepMode.AutoFleetSave.ForceUnsafe;
 
+			bool recall = false;
+			if ((bool) settings.SleepMode.AutoFleetSave.Recall)
+				recall = true;
 
 			if (celestial.Resources.Deuterium == 0) {
 				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Skipping fleetsave from {celestial.ToString()}: there is no fuel!");
-				if (fromTelegram)
-					telegramMessenger.SendMessage($"{celestial.ToString()}: there is no fuel!");
 				return;
 			}
 
@@ -1310,18 +1197,12 @@ namespace Tbot {
 			int fleetId = 0;
 			bool AlreadySent = false; //permit to swith to Harvest mission if not enough fuel to Deploy if celestial far away
 
-			//Doing DefaultMission or telegram /ghostto mission
-			Missions mission;
-			if (!Missions.TryParse(settings.SleepMode.AutoFleetSave.DefaultMission, out mission)) {
-				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, "Error: Could not parse 'DefaultMission' from settings, value set to Harvest.");
-				mission = Missions.Harvest;
-			}
-
+			Missions mission = Missions.Deploy;
 			if (TelegramMission != Missions.None)
 				mission = TelegramMission;
 
 			List<FleetHypotesis> fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
-			if (fleetHypotesis.Count() > 0) {
+			if (fleetHypotesis.Count() > 0) { 
 				foreach (FleetHypotesis fleet in fleetHypotesis.OrderBy(pf => pf.Fuel).ThenBy(pf => pf.Duration <= minDuration)) {
 					Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"checking {mission} fleet to: {fleet.Destination}");
 					if (CheckFuel(fleet, celestial)) {
@@ -1335,23 +1216,38 @@ namespace Tbot {
 					}
 				}
 			}
-
-			//If /ghostto -> leaving function if failed
-			if (fromTelegram && !AlreadySent && mission == Missions.Harvest && fleetHypotesis.Count() == 0) {
-				telegramMessenger.SendMessage($"No debris field found for {mission}, try to /spycrash.");
-				return;
-			} else if (fromTelegram && !AlreadySent && fleetHypotesis.Count() >= 0) {
-				telegramMessenger.SendMessage($"Available fuel: {celestial.Resources.Deuterium}\nNo destination found for {mission}, try to reduce ghost time.");
-				return;
-			}
-
-			//Doing Deploy
-			if (!AlreadySent) {
-				if (mission == Missions.Harvest) { mission = Missions.Deploy; } else { mission = Missions.Harvest; };
-				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.ToString()} no Harvest possible, checking Deploy..");
-				mission = Missions.Deploy;
+			if (!AlreadySent) { 
+				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.ToString()} no Deploy possible doing Harvest..");
+				mission = Missions.Harvest;
 				fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
-				if (fleetHypotesis.Count > 0) {
+
+				if (fleetHypotesis.Count() == 0 && !forceUnsafe ) {
+					Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Skipping fleetsave from {celestial.ToString()} no Deploy or Harvest possible and forceUnsafe disabled!");
+
+				}
+				else {  //fleetHypotesis.Count() == 0 && forceUnsafe enabled
+					Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Skipping fleetsave from {celestial.ToString()} no Deploy or Harvest possible doing Unsafe..");
+					decimal speed = 100;
+					TelegramSwitch(speed, celestial);
+					/*
+					Need to modify this, going to 1,1,1 is bad, better Harvest near origin SS, Spy near origin SS, colonize near origin SS
+
+					if (fleetHypotesis.First().Destination.IsSame(new Coordinate(1, 1, 1, Celestials.Planet)) && celestial.Ships.Recycler > 0) {
+						mission = Missions.Harvest;
+						fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
+					}
+					if (fleetHypotesis.First().Destination.IsSame(new Coordinate(1, 1, 1, Celestials.Planet)) && celestial.Ships.EspionageProbe > 0) {
+						mission = Missions.Spy;
+						fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
+					}
+					if (fleetHypotesis.First().Destination.IsSame(new Coordinate(1, 1, 1, Celestials.Planet)) && celestial.Ships.ColonyShip > 0 && Helpers.CalcMaxPlanets(researches.Astrophysics) == celestials.Unique().Where(c => c.Coordinate.Type == Celestials.Planet).Count()) {
+						mission = Missions.Colonize;
+						fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
+					}
+					*/
+				}
+				if (fleetHypotesis.Count() > 0) {
+					Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"No destination found mission type changed to {mission}");
 					foreach (FleetHypotesis fleet in fleetHypotesis.OrderBy(pf => pf.Fuel).ThenBy(pf => pf.Duration <= minDuration)) {
 						Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"checking {mission} fleet to: {fleet.Destination}");
 						if (CheckFuel(fleet, celestial)) {
@@ -1359,96 +1255,28 @@ namespace Tbot {
 
 							if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
 								possibleFleet = fleet;
-								AlreadySent = true;
 								break;
 							}
 						}
 					}
-				}
-			}
-			//Doing colonize
-			if (!AlreadySent && celestial.Ships.ColonyShip > 0) {
-				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.ToString()} no Moon/Planet to switch on, checking Colonize destination...");
-				mission = Missions.Colonize;
-				fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
-				if (fleetHypotesis.Count > 0) {
-					foreach (FleetHypotesis fleet in fleetHypotesis.OrderBy(pf => pf.Fuel).ThenBy(pf => pf.Duration <= minDuration)) {
-						Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"checking {mission} fleet to: {fleet.Destination}");
-						if (CheckFuel(fleet, celestial)) {
-							fleetId = SendFleet(fleet.Origin, fleet.Ships, fleet.Destination, fleet.Mission, fleet.Speed, payload, userInfo.Class);
-
-							if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
-								possibleFleet = fleet;
-								AlreadySent = true;
-								break;
-							}
-						}
-					}
-				}
-			}
-			//Doing Spy
-			if (!AlreadySent && celestial.Ships.EspionageProbe > 0) {
-				mission = Missions.Spy;
-				fleetHypotesis = GetFleetSaveDestination(celestials, celestial, departureTime, minDuration, mission, maxDeuterium, forceUnsafe);
-				if (fleetHypotesis.Count > 0) {
-					foreach (FleetHypotesis fleet in fleetHypotesis.OrderBy(pf => pf.Fuel).ThenBy(pf => pf.Duration <= minDuration)) {
-						Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"checking {mission} fleet to: {fleet.Destination}");
-						if (CheckFuel(fleet, celestial)) {
-							fleetId = SendFleet(fleet.Origin, fleet.Ships, fleet.Destination, fleet.Mission, fleet.Speed, payload, userInfo.Class);
-
-							if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
-								possibleFleet = fleet;
-								AlreadySent = true;
-								break;
-							}
-						}
-					}
+				} else {
+					telegramMessenger.SendMessage($"Available fuel: {celestial.Resources.Deuterium}\nNo destination found, try to reduce ghost time.");
+					return;
 				}
 			}
 
-			//Doing switch
-			bool hasMoon = celestials.Count(c => c.HasCoords(new Coordinate(celestial.Coordinate.Galaxy, celestial.Coordinate.System, celestial.Coordinate.Position, Celestials.Moon))) == 1;
-			if (!AlreadySent && hasMoon) {
-				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.ToString()} no Deploy possible (missing fuel?), checking for switch if has Moon");
-				//var validSpeeds = userInfo.Class == CharacterClass.General ? Speeds.GetGeneralSpeedsList() : Speeds.GetNonGeneralSpeedsList();
-				//Random randomSpeed = new Random();
-				//decimal speed = validSpeeds[randomSpeed.Next(validSpeeds.Count)];
-				decimal speed = 100;
-				AlreadySent = TelegramSwitch(speed, celestial);
+			if (recall && fleetId != 0 || fleetId != -1 || fleetId != -2) {
+				Fleet fleet = fleets.Single(fleet => fleet.ID == fleetId);
+				DateTime time = GetDateTime();
+				var interval = ((minDuration / 2) * 1000) + Helpers.CalcRandomInterval(IntervalType.AMinuteOrTwo);
+				if (interval <= 0)
+					interval = Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+				DateTime newTime = time.AddMilliseconds(interval);
+				timers.Add($"RecallTimer-{fleetId.ToString()}", new Timer(RetireFleet, fleet, interval, Timeout.Infinite));
+				Helpers.WriteLog(LogType.Info, LogSender.FleetScheduler, $"The fleet will be recalled at {newTime.ToString()}");
+				telegramMessenger.SendMessage($"Fleet {fleetId} send to {possibleFleet.Mission}, fuel consumed: {possibleFleet.Fuel.ToString("#,#", CultureInfo.InvariantCulture)}, recalled at {newTime.ToString()}");
 			}
 
-			if (!AlreadySent) {
-				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleetsave from {celestial.Coordinate.ToString()} no Moon/Planet to switch on, and Unsafe disabled, you gonna get hit!");
-				if ((bool) settings.TelegramMessenger.Active){
-					telegramMessenger.SendMessage($"Fleetsave from {celestial.Coordinate.ToString()} No destination found!, you gonna get hit!");
-				}
-				return;
-			}
-
-			
-			if ((bool) settings.SleepMode.AutoFleetSave.Recall && AlreadySent) {
-				if (fleetId != 0 && fleetId != -1 && fleetId != -2) {
-					Fleet fleet = fleets.Single(fleet => fleet.ID == fleetId);
-					DateTime time = GetDateTime();
-					var interval = ((minDuration / 2) * 1000) + Helpers.CalcRandomInterval(IntervalType.AMinuteOrTwo);
-					if (interval <= 0)
-						interval = Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
-					DateTime newTime = time.AddMilliseconds(interval);
-					timers.Add($"RecallTimer-{fleetId.ToString()}", new Timer(RetireFleet, fleet, interval, Timeout.Infinite));
-					Helpers.WriteLog(LogType.Info, LogSender.FleetScheduler, $"The fleet will be recalled at {newTime.ToString()}");
-					if ((bool) settings.TelegramMessenger.Active || fromTelegram)
-						telegramMessenger.SendMessage($"Fleet {fleetId} send to {possibleFleet.Mission} on {possibleFleet.Destination.ToString()}, fuel consumed: {possibleFleet.Fuel.ToString("#,#", CultureInfo.InvariantCulture)}, recalled at {newTime.ToString()}");
-				}
-			}
-			else {
-				if (fleetId != 0 && fleetId != -1 && fleetId != -2) {
-					Fleet fleet = fleets.Single(fleet => fleet.ID == fleetId);
-					Helpers.WriteLog(LogType.Info, LogSender.FleetScheduler, $"Fleet {fleetId} send to {possibleFleet.Mission} on {possibleFleet.Destination.ToString()}, arrive at {possibleFleet.Duration} fuel consumed: {possibleFleet.Fuel.ToString("#,#", CultureInfo.InvariantCulture)}");
-					if ((bool) settings.TelegramMessenger.Active || fromTelegram)
-						telegramMessenger.SendMessage($"Fleet {fleetId} send to {possibleFleet.Mission} on {possibleFleet.Destination.ToString()}, arrive at {possibleFleet.Duration} fuel consumed: {possibleFleet.Fuel.ToString("#,#", CultureInfo.InvariantCulture)}");
-				}
-			}
-				
 		}
 
 		private static bool CheckFuel(FleetHypotesis fleetHypotesis, Celestial celestial) {
@@ -1491,69 +1319,80 @@ namespace Tbot {
 						}
 					}
 					break;
-				case Missions.Colonize:					
-					galaxyInfo = ogamedService.GetGalaxyInfo(origin.Coordinate);
-					int pos = 1;
-					foreach (var planet in galaxyInfo.Planets) {
-						if (planet == null)
-							possibleDestinations.Add(new(origin.Coordinate.Galaxy, origin.Coordinate.System, pos));
-						pos =+ 1;
+				case Missions.Colonize:
+					for (int pos = 1; pos <= 15; pos++) {
+						if (pos == origin.Coordinate.Position)
+							continue;
+						galaxyInfo = ogamedService.GetGalaxyInfo(origin.Coordinate);
+						List<int> occupiedPos = new();
+						foreach (var planet in galaxyInfo.Planets) {
+							occupiedPos.Add(planet.Coordinate.Position);
+						}
+						if (occupiedPos.Any(op => op == pos))
+							continue;
+
+						possibleDestinations.Add(new(origin.Coordinate.Galaxy, origin.Coordinate.System, pos, Celestials.Planet));
 					}
+					foreach (var possibleDestination in possibleDestinations) {
+						foreach (var currentSpeed in validSpeeds) {
+							FleetPrediction fleetPrediction = Helpers.CalcFleetPrediction(origin.Coordinate, possibleDestination, origin.Ships.GetMovableShips(), mission, currentSpeed, researches, serverData, userInfo.Class);
 
-					if (possibleDestinations.Count() > 0) {
-						foreach (var possibleDestination in possibleDestinations) {
-							foreach (var currentSpeed in validSpeeds) {
-								FleetPrediction fleetPrediction = Helpers.CalcFleetPrediction(origin.Coordinate, possibleDestination, origin.Ships.GetMovableShips(), mission, currentSpeed, researches, serverData, userInfo.Class);
-
-								FleetHypotesis fleetHypotesis = new() {
-									Origin = origin,
-									Destination = possibleDestination,
-									Ships = origin.Ships.GetMovableShips(),
-									Mission = mission,
-									Speed = currentSpeed,
-									Duration = fleetPrediction.Time,
-									Fuel = fleetPrediction.Fuel
-								};
-								if (fleetHypotesis.Duration >= minFlightTime / 2 && fleetHypotesis.Fuel <= maxFuel) {
-									possibleFleets.Add(fleetHypotesis);
-									break;
-								}
+							FleetHypotesis fleetHypotesis = new() {
+								Origin = origin,
+								Destination = possibleDestination,
+								Ships = origin.Ships.GetMovableShips(),
+								Mission = mission,
+								Speed = currentSpeed,
+								Duration = fleetPrediction.Time,
+								Fuel = fleetPrediction.Fuel
+							};
+							if (fleetHypotesis.Duration >= minFlightTime / 2 && fleetHypotesis.Fuel <= maxFuel) {
+								possibleFleets.Add(fleetHypotesis);
+								break;
 							}
 						}
 					}
 					break;
-				
+
 				case Missions.Harvest:
-					int playerid = userInfo.PlayerID;
-					int sys = 0;
-					for ( sys = origin.Coordinate.System - 5 ; sys <= origin.Coordinate.System + 5; sys++) {
-						galaxyInfo = ogamedService.GetGalaxyInfo(origin.Coordinate.Galaxy, sys);
-						foreach (var planet in galaxyInfo.Planets) {
-							if (planet != null && planet.Debris != null && planet.Debris.Resources.TotalResources > 0) {
-								possibleDestinations.Add(new(planet.Coordinate.Galaxy, planet.Coordinate.System, planet.Coordinate.Position, Celestials.Debris));
+					galaxyInfo = ogamedService.GetGalaxyInfo(origin.Coordinate.Galaxy, origin.Coordinate.System);
+					List<int> harvestablePos = new();
+					foreach (var planet in galaxyInfo.Planets ) {
+						if (planet != null && planet.Debris != null && planet.Debris.Resources.TotalResources > 0) {
+							possibleDestinations.Add(new(planet.Coordinate.Galaxy, planet.Coordinate.System, planet.Coordinate.Position, Celestials.Debris));
+						}		
+					}
+					
+					if (possibleDestinations.Count == 0) {
+						int sys = 0;
+						for ( sys = origin.Coordinate.System - 5 ; sys <= origin.Coordinate.System + 5; sys++) {
+							galaxyInfo = ogamedService.GetGalaxyInfo(origin.Coordinate.Galaxy, sys);
+							harvestablePos = new();
+							foreach (var planet in galaxyInfo.Planets) {
+								if (planet != null && planet.Debris != null && planet.Debris.Resources.TotalResources > 0) {
+									Console.WriteLine(planet.Debris.Resources.TotalResources);
+									possibleDestinations.Add(new(planet.Coordinate.Galaxy, planet.Coordinate.System, planet.Coordinate.Position, Celestials.Debris));
+								}
 							}
 						}
 					}
-					
-					
-					if (possibleDestinations.Count() > 0) {
-						foreach (var possibleDestination in possibleDestinations) {
-							foreach (var currentSpeed in validSpeeds) {
-								FleetPrediction fleetPrediction = Helpers.CalcFleetPrediction(origin.Coordinate, possibleDestination, origin.Ships.GetMovableShips(), mission, currentSpeed, researches, serverData, userInfo.Class);
 
-								FleetHypotesis fleetHypotesis = new() {
-									Origin = origin,
-									Destination = possibleDestination,
-									Ships = origin.Ships.GetMovableShips(),
-									Mission = mission,
-									Speed = currentSpeed,
-									Duration = fleetPrediction.Time,
-									Fuel = fleetPrediction.Fuel
-								};
-								if (fleetHypotesis.Duration >= minFlightTime / 2 && fleetHypotesis.Fuel <= maxFuel) {
-									possibleFleets.Add(fleetHypotesis);
-									break;
-								}
+					foreach (var possibleDestination in possibleDestinations) {
+						foreach (var currentSpeed in validSpeeds) {
+							FleetPrediction fleetPrediction = Helpers.CalcFleetPrediction(origin.Coordinate, possibleDestination, origin.Ships.GetMovableShips(), mission, currentSpeed, researches, serverData, userInfo.Class);
+
+							FleetHypotesis fleetHypotesis = new() {
+								Origin = origin,
+								Destination = possibleDestination,
+								Ships = origin.Ships.GetMovableShips(),
+								Mission = mission,
+								Speed = currentSpeed,
+								Duration = fleetPrediction.Time,
+								Fuel = fleetPrediction.Fuel
+							};
+							if (fleetHypotesis.Duration >= minFlightTime / 2 && fleetHypotesis.Fuel <= maxFuel) {
+								possibleFleets.Add(fleetHypotesis);
+								break;
 							}
 						}
 					}
@@ -1565,7 +1404,7 @@ namespace Tbot {
 						.Select(planet => planet.Coordinate)
 						.ToList();
 					
-					if (possibleDestinations.Count == 0) {
+					if (possibleDestinations.Count == 0 && forceUnsafe) {
 						possibleDestinations = celestials
 							.Where(planet => planet.ID != origin.ID)
 							.Select(planet => planet.Coordinate)
@@ -1595,11 +1434,28 @@ namespace Tbot {
 				default:
 					break;
 			}
-			if (possibleFleets.Count() > 0) {
+			if (possibleFleets.Count > 0) {
 				return possibleFleets;
 
 			} else {
 				return new List<FleetHypotesis>();
+				/*
+				if ( mission = Missions.Harvest ) {
+					mission = Missions.Transport;
+					FleetPrediction fleetPrediction = Helpers.CalcFleetPrediction(origin.Coordinate, new Coordinate(), origin.Ships.GetMovableShips(), mission, Speeds.TenPercent, researches, serverData, userInfo.Class);
+					FleetHypotesis fleetHypotesis = new() {
+						Origin = origin,
+						Destination = new Coordinate(),
+						Ships = origin.Ships.GetMovableShips(),
+						Mission = mission,
+						Speed = Speeds.TenPercent,
+						Duration = fleetPrediction.Time,
+						Fuel = fleetPrediction.Fuel
+					};
+					possibleFleets.Add(fleetHypotesis);
+				}
+				return possibleFleets;
+				*/
 			}
 		}
 		
@@ -1849,19 +1705,11 @@ namespace Tbot {
 			}
 		}
 
-
-		public static bool TelegramIsUnderAttack() {
-			bool result = ogamedService.IsUnderAttack();
-
-			return result;
-		}
-
-
 		public static void WakeUpNow(object state) {
 			if (timers.TryGetValue("TelegramSleepModeTimer", out Timer value))
 				value.Dispose();
-				timers.Remove("TelegramSleepModeTimer");
-				telegramMessenger.SendMessage($"[{userInfo.PlayerName} ({serverData.Name})] Bot woke up!");
+			timers.Remove("TelegramSleepModeTimer");
+			telegramMessenger.SendMessage($"[{userInfo.PlayerName} ({serverData.Name})] Bot woke up!");
 
 			Helpers.WriteLog(LogType.Info, LogSender.SleepMode, "Bot woke up!");
 
@@ -1891,30 +1739,6 @@ namespace Tbot {
 			}
 		}
 
-		private static void FakeActivity() {
-			//checking if under attack by making activity on planet/moon configured in settings (otherwise make acti on latest activated planet)
-			// And make activity on one more random planet to fake real player
-			Celestial celestial;
-			Celestial randomCelestial;
-			celestial = celestials
-				.Unique()
-				.Where(c => c.Coordinate.Galaxy == (int) settings.Brain.AutoMine.Transports.Origin.Galaxy)
-				.Where(c => c.Coordinate.System == (int) settings.Brain.AutoMine.Transports.Origin.System)
-				.Where(c => c.Coordinate.Position == (int) settings.Brain.AutoMine.Transports.Origin.Position)
-				.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) settings.Brain.AutoMine.Transports.Origin.Type))
-				.SingleOrDefault() ?? new() { ID = 0 };
-
-			Random random = new Random();
-			randomCelestial = celestials[random.Next(celestials.Count())];
-			ogamedService.GetDefences(randomCelestial);
-
-			if (celestial.ID != 0) {
-				ogamedService.GetDefences(celestial);
-			}
-
-			return;
-		}
-
 		private static void Defender(object state) {
 			try {
 				// Wait for the thread semaphore to avoid the concurrency with itself
@@ -1927,7 +1751,6 @@ namespace Tbot {
 					return;
 				}
 
-				FakeActivity();
 				fleets = UpdateFleets();
 				bool isUnderAttack = ogamedService.IsUnderAttack();
 				DateTime time = GetDateTime();
@@ -1945,7 +1768,7 @@ namespace Tbot {
 					Helpers.WriteLog(LogType.Info, LogSender.Defender, "Your empire is safe");
 				}
 				int interval = Helpers.CalcRandomInterval((int) settings.Defender.CheckIntervalMin, (int) settings.Defender.CheckIntervalMax);
-				if (interval <= 0)	
+				if (interval <= 0)
 					interval = Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
 				DateTime newTime = time.AddMilliseconds(interval);
 				timers.GetValueOrDefault("DefenderTimer").Change(interval, Timeout.Infinite);
@@ -2203,7 +2026,12 @@ namespace Tbot {
 						Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Delaying...");
 						var time = GetDateTime();
 						fleets = UpdateFleets();
-						long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						long interval;
+						try {
+							interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						} catch {
+							interval = Helpers.CalcRandomInterval((int) settings.AutoResearch.CheckIntervalMin, (int) settings.AutoResearch.CheckIntervalMax);
+						}
 						var newTime = time.AddMilliseconds(interval);
 						timers.GetValueOrDefault("AutoResearchTimer").Change(interval, Timeout.Infinite);
 						Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Next AutoResearch check at {newTime.ToString()}");
@@ -3253,15 +3081,20 @@ namespace Tbot {
 					Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Stopping AutoMine check for {celestial.ToString()}.");
 					if (timers.TryGetValue($"AutoMineTimer-{celestial.ID.ToString()}", out Timer value))
 						value.Dispose();
-						timers.Remove(autoMineTimer);
+					timers.Remove(autoMineTimer);
 				} else if (delay) {
 					Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Delaying...");
 					time = GetDateTime();
 					fleets = UpdateFleets();
-					long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+					long interval;
+					try {
+						interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+					} catch {
+						interval = Helpers.CalcRandomInterval((int) settings.AutoMine.CheckIntervalMin, (int) settings.AutoMine.CheckIntervalMax);
+					}
 					if (timers.TryGetValue(autoMineTimer, out Timer value))
 						value.Dispose();
-						timers.Remove(autoMineTimer);
+					timers.Remove(autoMineTimer);
 					newTime = time.AddMilliseconds(interval);
 					timers.Add(autoMineTimer, new Timer(AutoMine, celestial, interval, Timeout.Infinite));
 					Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Next AutoMine check for {celestial.ToString()} at {newTime.ToString()}");
@@ -3272,7 +3105,7 @@ namespace Tbot {
 
 					if (timers.TryGetValue(autoMineTimer, out Timer value))
 						value.Dispose();
-						timers.Remove(autoMineTimer);
+					timers.Remove(autoMineTimer);
 
 					newTime = time.AddMilliseconds(interval);
 					timers.Add(autoMineTimer, new Timer(AutoMine, celestial, interval, Timeout.Infinite));
@@ -3756,7 +3589,12 @@ namespace Tbot {
 						Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Delaying...");						
 						fleets = UpdateFleets();
 						var time = GetDateTime();
-						long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						long interval;
+						try {
+							interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						} catch {
+							interval = Helpers.CalcRandomInterval((int) settings.AutoRepatriate.CheckIntervalMin, (int) settings.AutoRepatriate.CheckIntervalMax);
+						}
 						var newTime = time.AddMilliseconds(interval);
 						timers.GetValueOrDefault("RepatriateTimer").Change(interval, Timeout.Infinite);
 						Helpers.WriteLog(LogType.Info, LogSender.Brain, $"Next repatriate check at {newTime.ToString()}");
@@ -3809,7 +3647,6 @@ namespace Tbot {
 					speed == Speeds.NinetyfivePercent
 				)
 			) {*/
-
 			if (!Helpers.GetValidSpeedsForClass(playerClass).Any(s => s == speed)) {
 				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, "Unable to send fleet: speed not available for your class");
 				return 0;
@@ -3944,13 +3781,9 @@ namespace Tbot {
 
 		public static void TelegramMesgAttacker(string message) {
 			attacks = ogamedService.GetAttacks();
-			List<int> playerid = new List<int>();
-
 			foreach (AttackerFleet attack in attacks) {
-				if (attack.AttackerID != 0 && !playerid.Any(s => s == attack.AttackerID)) {
+				if (attack.AttackerID != 0) {
 					var result = ogamedService.SendMessage(attack.AttackerID, message);
-					playerid.Add(attack.AttackerID);
-
 					if (result)
 						telegramMessenger.SendMessage($"Message succesfully sent to {attack.AttackerName}.");
 					else
@@ -4096,7 +3929,7 @@ namespace Tbot {
 					return;
 				}
 
-				if ((bool) settings.Expeditions.Active || timers.TryGetValue("ExpeditionsTimer", out Timer value)) {
+				if ((bool) settings.Expeditions.Active) {
 					researches = UpdateResearches();
 					if (researches.Astrophysics == 0) {
 						Helpers.WriteLog(LogType.Info, LogSender.Expeditions, "Skipping: Astrophysics not yet researched!");
@@ -4365,7 +4198,12 @@ namespace Tbot {
 						Helpers.WriteLog(LogType.Info, LogSender.Expeditions, $"Delaying...");
 						var time = GetDateTime();
 						fleets = UpdateFleets();
-						long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						long interval;
+						try {
+							interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						} catch {
+							interval = Helpers.CalcRandomInterval((int) settings.Expeditions.CheckIntervalMin, (int) settings.Expeditions.CheckIntervalMax);
+						}
 						var newTime = time.AddMilliseconds(interval);
 						timers.GetValueOrDefault("ExpeditionsTimer").Change(interval, Timeout.Infinite);
 						Helpers.WriteLog(LogType.Info, LogSender.Expeditions, $"Next check at {newTime.ToString()}");
@@ -4547,7 +4385,12 @@ namespace Tbot {
 						Helpers.WriteLog(LogType.Info, LogSender.Harvest, $"Delaying...");
 						var time = GetDateTime();
 						fleets = UpdateFleets();
-						long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						long interval;
+						try {
+							interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						} catch {
+							interval = Helpers.CalcRandomInterval((int) settings.AutoHarvest.CheckIntervalMin, (int) settings.AutoHarvest.CheckIntervalMax);
+						}
 						var newTime = time.AddMilliseconds(interval);
 						timers.GetValueOrDefault("HarvestTimer").Change(interval, Timeout.Infinite);
 						Helpers.WriteLog(LogType.Info, LogSender.Harvest, $"Next check at {newTime.ToString()}");
@@ -4715,7 +4558,13 @@ namespace Tbot {
 						Helpers.WriteLog(LogType.Info, LogSender.Colonize, $"Delaying...");
 						var time = GetDateTime();
 						fleets = UpdateFleets();
-						long interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						long interval;
+						try {
+							interval = (fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
+						}
+						catch {
+							interval = Helpers.CalcRandomInterval((int) settings.AutoColonize.CheckIntervalMin, (int) settings.AutoColonize.CheckIntervalMax);
+						}
 						var newTime = time.AddMilliseconds(interval);
 						timers.GetValueOrDefault("ColonizeTimer").Change(interval, Timeout.Infinite);
 						Helpers.WriteLog(LogType.Info, LogSender.Colonize, $"Next check at {newTime}");

--- a/TBot/Services/OgamedService.cs
+++ b/TBot/Services/OgamedService.cs
@@ -746,7 +746,7 @@ namespace Tbot.Services {
 			request.AddParameter("metal", payload.Metal, ParameterType.GetOrPost);
 			request.AddParameter("crystal", payload.Crystal, ParameterType.GetOrPost);
 			request.AddParameter("deuterium", payload.Deuterium, ParameterType.GetOrPost);
-			request.AddParameter("food", payload.Food, ParameterType.GetOrPost);
+			//request.AddParameter("food", payload.Food, ParameterType.GetOrPost);
 
 			var result = JsonConvert.DeserializeObject<OgamedResponse>(Client.Execute(request).Content);
 			if (result.Status != "ok") {

--- a/TBot/Services/OgamedService.cs
+++ b/TBot/Services/OgamedService.cs
@@ -19,6 +19,9 @@ namespace Tbot.Services {
 				Timeout = 86400000,
 				ReadWriteTimeout = 86400000
 			};
+			if (credentials.BasicAuthUsername != "" && credentials.BasicAuthPassword != "") {
+				Client.Authenticator = new RestSharp.Authenticators.HttpBasicAuthenticator(credentials.BasicAuthUsername, credentials.BasicAuthPassword);
+			}
 		}
 
 		internal void ExecuteOgamedExecutable(Credentials credentials, string host = "localhost", int port = 8080, string captchaKey = "", ProxySettings proxySettings = null) {

--- a/TBot/TBot.csproj
+++ b/TBot/TBot.csproj
@@ -5,15 +5,15 @@
     <TargetFramework>net5.0</TargetFramework>
     <Nullable>disable</Nullable>
     <Authors>ELK-Lab</Authors>
-    <Version>0.2.57</Version>
+    <Version>0.2.58</Version>
     <StartupObject>Tbot.Program</StartupObject>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <Copyright>2022 © ELK-Lab</Copyright>
     <PackageLicenseExpression>https://licenses.nuget.org/MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://www.ogame-tbot.net</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ogame-tbot/TBot</RepositoryUrl>
-    <AssemblyVersion>0.2.57.0</AssemblyVersion>
-    <FileVersion>0.2.57.0</FileVersion>
+    <AssemblyVersion>0.2.58.0</AssemblyVersion>
+    <FileVersion>0.2.58.0</FileVersion>
     <Description>OGame Bot</Description>
     <SignAssembly>False</SignAssembly>
     <AssemblyOriginatorKeyFile>ELK-Lab.pfx</AssemblyOriginatorKeyFile>

--- a/TBot/settings.json
+++ b/TBot/settings.json
@@ -4,10 +4,14 @@
 		"Email": "",
 		"Password": "",
 		"Language": "",
-		"LobbyPioneers": false
+		"LobbyPioneers": false,
+		"BasicAuth": {
+			"Username": "",
+			"Password": ""
+		}
 	},
 	"General": {
-		"UserAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.82 Safari/537.36",
+		"UserAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36",
 		"Host": "localhost",
 		"Port": "8080",
 		"Proxy": {


### PR DESCRIPTION
# CHANGES

## TELEGRAM
- Better handling of exception that would make the bot crash.
- /spycrash [auto/coord] [crash a prob at a random target (-2 -> +2 system)] [crash a prob on planet coordinate submitted]
- /getcelestials: list your celestials (usefull to use will /celestial if you dont remember all your coordinate)
- /attacked: say if you're (still) under attack or not
- /startdefender, /stopdefender
- /recall true/false: (prvious /recall changed to /cancel) Enable or disable auto recall fleet when /ghost, /ghostto, /ghostsleep, /deploy and bot autofleetsave (set recall to true/false into JSON settings)
- /startautopong, /stopautopong: send a telegram message every rounded up hours to check if alive (2pm, 3pm, 4pm...), can be adjusted into settings

- Added support of autofleetsave function using TelegramCurrentCelestial (defined by /celestial), this allows to use all /ghost commands and /spycrash, /switch on the desired celestial without editing settings.json file
-> Remember, each Bot features like [TARGET] repatriate (/collect), [ORIGIN] expedition, [TARGET] autoresearch, [ORIGIN] Automine transports will still be via JSON planet information, but you can modify from telegram using /editsettings command.
-> Therefore, do not forget to change celestial focus by using "/celestial" before "/getinfo", "/ghost", "/ghostto", "/ghostsleep", "/switch" or /spycrash commands

You can directly copy/paste the commands list below to your "editcommands" Bot to @BotFather:
 ```
ghostsleep - '/ghostsleep 5 Harvest' -> Wait for fleets to return, ghost on harvest and sleep for 5hours
ghost - '/ghost 4' -> Ghost fleet for 4 hours,let bot chose mission type
ghostto - '/ghostto 4 Harvest'
switch - '/switch 5' -> switch current celestial resources and fleets to its planet or moon at 50% speed
spycrash - Create a debris field by crashing a probe on target planet
recall - '/recall true/false' -> enable/disable fleet auto recall
stopexpe - Stop sending expedition
startexpe - Start sending expedition
startdefender - start defender
stopdefender - stop defender
stopautomine - stop brain automine
startautomine - start brain automine
stopautopong - stop telegram autopong
startautopong - start telegram autopong (send telegram message every rounded hours)
collect - Collect planets resources to JSON setting celestial
msg - '/msg hello dude' -> Send 'hello dude' to current attacker
sleep - '/sleep 1' -> Stop bot, inactive for 1 hours
wakeup - Wakeup bot
cancel - '/cancel 65656' -> cancel ongoing fleet id 65656
getcelestials - return the coordinate list and type of all your celestials
attacked - check if you're (still) under attack
celestial - '/celestial 2:45:8 Moon' (Moon/Planet) Update program current celestial target
getinfo - Get current celestial resources and ships
editsettings - '/editsettings 2:425:9 moon -> Edit JSON file to change: Expedition, Transport, Repatriate and AutoReseach (Origin/Target) celestial
ping - Ping bot
help - Display this help
 ```
 
 
## TBOT 
- Autofleetsave:
->Improved behavior and forceUnsafe removed (now all possibility are checked from safer to unsafer, between getting hit and doing unsafe, i guess u prefer doing unsafe)
-> default mission set to Harvest to consume less fuel (but defaultMission has been added to AutoFleetSave settings to let you chose what you prefer)

### Current autofleetsave behavior:
``` 
1- Check for Default mission into settings to go first (default harvest, harvest/deploy only suggered) (except if from telegram command with mission type submit)
2- Check for available destination, if found, go for it
3- If no destination found or not enough fuel, check for Deploy/harvest depending on previous mission, if found,  go for it
4- If no destination found or not enough fuel, check for Colonize
5- If no destination found or not enough fuel, check for Spy
6- Finally If no destination found or not enough fuel, if planet has a moon, do Switch from moon to pla and vise versa
```

- Feature TelegramAutoPong added -> added to json settings

- Defender: FakeActivity()
-> when "is-under-attack" from defender was made, the last planet visited by the bot was activated (automine, collect, etc), which may make your main planet (ships+resources) inactive for long
-> now fakeactivity() perform activity on one random celestial + your main celestial (from AutoMine.Transport settings) in last, each time defender check for attack, which i believe, fake better a real player

## FIXES
- TelegramMesgAttacker() was sending twice the mesg to the same attacker if several fleet was sent
- GetFleetSaveDestination: fix case Missions.Colonize (not tested)
