### PR TITLE
Small Improvements

### DIFF
--- a/TBot/Includes/Helpers.cs
+++ b/TBot/Includes/Helpers.cs
@@ -99,9 +99,16 @@ namespace Tbot.Includes {
 				int secs = m.Groups[3].Success ? Int32.Parse(m.Groups[3].Value) : 0;
 
 				duration = (hours * 60 * 60) + (mins * 60) + secs;
+			} else {
+				throw new Exception($"Invalid string {timeString}");
 			}
 
 			return duration;
+		}
+
+		public static string TimeSpanToString(TimeSpan delta) {
+
+			return string.Format("{0} days {1:00}:{2:00}:{3:00}", delta.Days, delta.Hours, delta.Minutes, delta.Seconds);
 		}
 
 		public static int CalcRandomInterval(IntervalType type) {

--- a/TBot/Includes/Helpers.cs
+++ b/TBot/Includes/Helpers.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Threading;
 using System.Linq;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace Tbot.Includes {
 
@@ -16,19 +17,21 @@ namespace Tbot.Includes {
 		}
 
 		public static void LogToConsole(LogType type, LogSender sender, string message) {
+			ConsoleColor consoleColor = sender switch {
+				LogSender.Brain => ConsoleColor.Blue,
+				LogSender.Defender => ConsoleColor.DarkGreen,
+				LogSender.Expeditions => ConsoleColor.Cyan,
+				LogSender.FleetScheduler => ConsoleColor.DarkMagenta,
+				LogSender.Harvest => ConsoleColor.Green,
+				LogSender.Colonize => ConsoleColor.DarkRed,
+				LogSender.AutoFarm => ConsoleColor.DarkCyan,
+				LogSender.SleepMode => ConsoleColor.DarkBlue,
+				LogSender.Tbot => ConsoleColor.DarkYellow,
+				LogSender.OGameD => ConsoleColor.DarkCyan,
+				_ => ConsoleColor.Gray
+			};
 			Console.ForegroundColor = type == LogType.Info
-				? sender switch {
-					LogSender.Brain => ConsoleColor.Blue,
-					LogSender.Defender => ConsoleColor.DarkGreen,
-					LogSender.Expeditions => ConsoleColor.Cyan,
-					LogSender.FleetScheduler => ConsoleColor.DarkMagenta,
-					LogSender.Harvest => ConsoleColor.Green,
-					LogSender.Colonize => ConsoleColor.DarkRed,
-					LogSender.AutoFarm => ConsoleColor.DarkCyan,
-					LogSender.SleepMode => ConsoleColor.DarkBlue,
-					LogSender.Tbot => ConsoleColor.DarkYellow,
-					_ => ConsoleColor.Gray
-				}
+				? consoleColor
 				: type switch {
 					LogType.Error => ConsoleColor.Red,
 					LogType.Warning => ConsoleColor.Yellow,
@@ -81,6 +84,24 @@ namespace Tbot.Includes {
 			Thread.Sleep(1000);
 			Console.Beep();
 			return;
+		}
+
+		public static long ParseDurationFromString(string timeString) {
+			long duration = 0;
+			string regExp = "^(\\d{1,2})?[h|H]?(\\d{1,2})?[m|M]?(\\d{1,2})?[s|S]?";
+
+			Regex re = new Regex(regExp);
+			Match m = re.Match(timeString);
+
+			if (m.Groups.Count == 4) {
+				int hours = m.Groups[1].Success ? Int32.Parse(m.Groups[1].Value) : 0;
+				int mins = m.Groups[2].Success ? Int32.Parse(m.Groups[2].Value) : 0;
+				int secs = m.Groups[3].Success ? Int32.Parse(m.Groups[3].Value) : 0;
+
+				duration = (hours * 60 * 60) + (mins * 60) + secs;
+			}
+
+			return duration;
 		}
 
 		public static int CalcRandomInterval(IntervalType type) {

--- a/TBot/Includes/TelegramMessenger.cs
+++ b/TBot/Includes/TelegramMessenger.cs
@@ -347,14 +347,14 @@ namespace Tbot.Includes {
 
 							case ("/sleep"):
 								if (message.Text.Split(' ').Length != 2) {
-									SendMessage(botClient, message.Chat, "Mission argument required!");
+									SendMessage(botClient, message.Chat, "Time argument required!");
 									return;
 								}
 								arg = message.Text.Split(' ')[1];
-								int sleepingtime = Int32.Parse(arg);
+								duration = Helpers.ParseDurationFromString(arg);
 
 								DateTime timeNow = Tbot.Program.GetDateTime();
-								DateTime WakeUpTime = timeNow.AddHours(sleepingtime);
+								DateTime WakeUpTime = timeNow.AddSeconds(duration);
 	
 								Tbot.Program.SleepNow(WakeUpTime);
 								return;
@@ -672,7 +672,7 @@ namespace Tbot.Includes {
 									"/recall - Enable/disable fleet auto recall. Format: <code>/recall true/false</code>\n" +
 									"/collect - Collect planets resources to JSON setting celestial\n" +
 									"/msg - Send a message to current attacker. Format: <code>/msg hello dude</code>\n" +
-									"/sleep - Stop bot for the specified amount of hours. Format: <code>/sleep 1</code>\n" +
+									"/sleep - Stop bot for the specified amount of hours. Format: <code>/sleep 4h3m or 3m50s</code>\n" +
 									"/wakeup - Wakeup bot\n" +
 									"/cancel - Cancel fleet with specified ID. Format: <code>/cancel 65656</code>\n" +
 									"/getcelestials - Return the list of your celestials\n" +

--- a/TBot/Includes/TelegramMessenger.cs
+++ b/TBot/Includes/TelegramMessenger.cs
@@ -154,6 +154,7 @@ namespace Tbot.Includes {
 								if(myMoons.Count > 0) {
 									int fleetSaved = 0;
 									foreach (Celestial moon in myMoons) {
+										SendMessage(botClient, message.Chat, $"Enqueueign FleetSave for {moon.ToString()}...");
 										Tbot.Program.AutoFleetSave(moon, false, duration, false, false, mission_to_do, true);
 										// Let's sleep a bit :)
 										fleetSaved++;
@@ -235,7 +236,7 @@ namespace Tbot.Includes {
 									Tbot.Program.TelegramSwitch(speed);
 									return;
 								}
-								SendMessage(botClient, message.Chat, $"{test} error: Spped argument must be 1 or 2 or 3 for 10%, 20%, 30% etc.");
+								SendMessage(botClient, message.Chat, $"{test} error: Speed argument must be 1 or 2 or 3 for 10%, 20%, 30% etc.");
 								return;
 
 

--- a/TBot/Includes/TelegramMessenger.cs
+++ b/TBot/Includes/TelegramMessenger.cs
@@ -100,12 +100,12 @@ namespace Tbot.Includes {
 
 							case ("/ghost"):
 								if (message.Text.Split(' ').Length != 2) {
-									SendMessage(botClient, message.Chat, "Duration (in hours) argument required! Format: <code>/ghost 4</code>", ParseMode.Html);
-									SendMessage(botClient, message.Chat, "Duration (in hours) argument required! Format: <code>/ghost 4</code>", ParseMode.Html);
+									SendMessage(botClient, message.Chat, "Duration (in hours) argument required! Format: <code>/ghost 4h3m or 3m50s or 1h</code>", ParseMode.Html);
+									SendMessage(botClient, message.Chat, "Duration (in hours) argument required! Format: <code>/ghost 4h3m or 3m50s or 1h</code>", ParseMode.Html);
 									return;
 								}
 								arg = message.Text.Split(' ')[1];
-								duration = Int32.Parse(arg) * 60 * 60; //second
+								duration = Helpers.ParseDurationFromString(arg);
 
 								celestial = Tbot.Program.TelegramGetCurrentCelestial();
 								Tbot.Program.AutoFleetSave(celestial, false, duration, false, false, Missions.None, true);
@@ -115,7 +115,7 @@ namespace Tbot.Includes {
 
 							case ("/ghostto"):
 								if (message.Text.Split(' ').Length != 3) {
-									SendMessage(botClient, message.Chat, "Duration (in hours) and mission arguments required! Format: <code>/ghostto 4 harvest</code>", ParseMode.Html);
+									SendMessage(botClient, message.Chat, "Duration (in hours) and mission arguments required! Format: <code>/ghostto 4h3m or 3m50s or 1h Harvest</code>", ParseMode.Html);
 									return;
 								}
 								arg = message.Text.Split(' ')[1];
@@ -127,7 +127,7 @@ namespace Tbot.Includes {
 									SendMessage(botClient, message.Chat, $"{test} error: Mission argument must be 'Harvest', 'Deploy', 'Transport', 'Spy' or 'Colonize'");
 									return;
 								}
-								duration = Int32.Parse(arg) * 60 * 60; //second
+								duration = Helpers.ParseDurationFromString(arg);
 
 								celestial = Tbot.Program.TelegramGetCurrentCelestial();
 								Tbot.Program.AutoFleetSave(celestial, false, duration, false, false, mission, true);
@@ -136,7 +136,7 @@ namespace Tbot.Includes {
 
 							case ("/ghostmoons"):
 								if (message.Text.Split(' ').Length != 3) {
-									SendMessage(botClient, message.Chat, "Duration (in hours) argument required! Format: <code>/ghostmoons 4 <mission></code>!");
+									SendMessage(botClient, message.Chat, "Duration (in hours) argument required! Format: <code>/ghostmoons 4h3m or 3m50s or 1h <mission></code>!");
 									return;
 								}
 
@@ -148,7 +148,7 @@ namespace Tbot.Includes {
 									SendMessage(botClient, message.Chat, $"{test} error: Mission argument must be 'Harvest', 'Deploy', 'Transport', 'Spy' or 'Colonize'");
 									return;
 								}
-								duration = Int32.Parse(arg) * 60 * 60;
+								duration = Helpers.ParseDurationFromString(arg);
 
 								List<Celestial> myMoons = Tbot.Program.celestials.Where(p => p.Coordinate.Type == Celestials.Moon).ToList();
 								if(myMoons.Count > 0) {
@@ -171,11 +171,11 @@ namespace Tbot.Includes {
 
 							case ("/ghostsleep"):
 								if (message.Text.Split(' ').Length != 3) {
-									SendMessage(botClient, message.Chat, "Duration (in hours) argument required! Format: <code>/ghostsleep 5 Harvest</code>", ParseMode.Html);
+									SendMessage(botClient, message.Chat, "Duration (in hours) argument required! Format: <code>/ghostsleep 4h3m or 3m50s or 1h Harvest</code>", ParseMode.Html);
 									return;
 								}
 								arg = message.Text.Split(' ')[1];
-								duration = Int32.Parse(arg) * 60 * 60; //seconds
+								duration = Helpers.ParseDurationFromString(arg);
 								test = message.Text.Split(' ')[2];
 								test = char.ToUpper(test[0]) + test.Substring(1);
 
@@ -192,11 +192,11 @@ namespace Tbot.Includes {
 
 							case ("/ghostsleepall"):
 								if (message.Text.Split(' ').Length != 3) {
-									SendMessage(botClient, message.Chat, "Duration (in hours) argument required! Format: <code>/ghostsleep 5 Harvest</code>", ParseMode.Html);
+									SendMessage(botClient, message.Chat, "Duration (in hours) argument required! Format: <code>/ghostsleep 4h3m or 3m50s or 1h Harvest</code>", ParseMode.Html);
 									return;
 								}
 								arg = message.Text.Split(' ')[1];
-								duration = Int32.Parse(arg) * 60 * 60; //seconds
+								duration = Helpers.ParseDurationFromString(arg);
 								test = message.Text.Split(' ')[2];
 								test = char.ToUpper(test[0]) + test.Substring(1);
 
@@ -216,7 +216,7 @@ namespace Tbot.Includes {
 									return;
 								}
 								arg = message.Text.Split(' ')[1];
-								duration = Int32.Parse(arg) * 60 * 60; //seconds
+								duration = Helpers.ParseDurationFromString(arg);
 
 								celestial = Tbot.Program.TelegramGetCurrentCelestial();
 								Tbot.Program.AutoFleetSave(celestial, false, duration, false, true, Missions.None, true, true);
@@ -658,12 +658,12 @@ namespace Tbot.Includes {
 									return;
 								}
 								SendMessage(botClient, message.Chat,
-									"/ghostsleep - Wait fleets return, ghost harvest for current celestial only, and sleep for 5hours <code>/ghostsleep 5 Harvest</code>\n" +
-									"/ghostsleepall - Wait fleets return, ghost harvest for all celestial and sleep for 5hours <code>/ghostsleep 5 Harvest</code>\n" +
+									"/ghostsleep - Wait fleets return, ghost harvest for current celestial only, and sleep for 5hours <code>/ghostsleep 4h3m or 3m50s Harvest</code>\n" +
+									"/ghostsleepall - Wait fleets return, ghost harvest for all celestial and sleep for 5hours <code>/ghostsleep 4h3m or 3m50s Harvest</code>\n" +
 									//"/ghostsleepexpe - Wait fleets return, ghost harvest, sleep for 5hours, but keep sending expedition: <code>/ghostsleepexpe 5 Harvest</code>\n" +
-									"/ghost - Ghost fleet for the specified amount of hours\n, let bot chose mission type. Format: <code>/ghost 4</code>\n" +
-									"/ghostto - Ghost for the specified amount of hours on the specified mission. Format: <code>/ghostto 4 Harvest</code>\n" +
-									"/ghostmoons - Ghost moons fleet for the specified amount of hours on the specified mission. Format: <code>/ghostto 4 Harvest</code>\n" +
+									"/ghost - Ghost fleet for the specified amount of hours\n, let bot chose mission type. Format: <code>/ghost 4h3m or 3m50s</code>\n" +
+									"/ghostto - Ghost for the specified amount of hours on the specified mission. Format: <code>/ghostto 4h3m or 3m50s Harvest</code>\n" +
+									"/ghostmoons - Ghost moons fleet for the specified amount of hours on the specified mission. Format: <code>/ghostto 4h30m Harvest</code>\n" +
 									"/switch - Switch current celestial resources and fleets to its planet or moon at the specified speed. Format: <code>/switch 5</code>\n" +
 									"/deploy - Deploy to celestial with full ships and resources. Format: <code>/deploy 3:41:9 moon/planet 10</code>\n" +
 									"/jumpgate - jumpgate to moon with full ships [full], or keeps needed cargo amount for resources [auto]. Format: <code>/jumpgate 2:41:9 auto/full</code>\n" +

--- a/TBot/Model/Enums.cs
+++ b/TBot/Model/Enums.cs
@@ -248,6 +248,7 @@ namespace Tbot.Model {
 
 	public enum LogSender {
 		Tbot,
+		OGameD,
 		Defender,
 		Brain,
 		Expeditions,
@@ -275,5 +276,11 @@ namespace Tbot.Model {
 		Colonize = 12,
 		AutoFarm = 13,
 		TelegramAutoPing = 14
+	}
+
+	public enum SendFleetCode:int {
+		GenericError = 0,
+		AfterSleepTime = -1,
+		NotEnoughSlots = -2
 	}
 }

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -3955,18 +3955,20 @@ namespace Tbot {
 								}
 								payload = Helpers.CalcMaxTransportableResources(ships, payload, researches.HyperspaceTechnology, userInfo.Class, serverData.ProbeCargo);
 
-								var fleetId = SendFleet(tempCelestial, ships, destinationCoordinate, Missions.Transport, Speeds.HundredPercent, payload);
-								if (fleetId == -1) {
-									stop = true;
-									return;
+								if (payload.TotalResources > 0) {
+									var fleetId = SendFleet(tempCelestial, ships, destinationCoordinate, Missions.Transport, Speeds.HundredPercent, payload);
+									if (fleetId == -1) {
+										stop = true;
+										return;
+									}
+									if (fleetId == -2) {
+										delay = true;
+										return;
+									}
+									TotalMet += payload.Metal;
+									TotalCri += payload.Crystal;
+									TotalDeut += payload.Deuterium;
 								}
-								if (fleetId == -2) {
-									delay = true;
-									return;
-								}
-								TotalMet += payload.Metal;
-								TotalCri += payload.Crystal;
-								TotalDeut += payload.Deuterium;
 							}
 							else {
 								Helpers.WriteLog(LogType.Warning, LogSender.Brain, $"Skipping {tempCelestial.ToString()}: there are no {preferredShip.ToString()}");
@@ -3977,7 +3979,11 @@ namespace Tbot {
 						}
 						celestials = newCelestials;
 						if ((bool) settings.TelegramMessenger.Active) {
-							telegramMessenger.SendMessage($"Resources sent!:\n{TotalMet} Metal\n{TotalCri} Crystal\n{TotalDeut} Deuterium");
+							if ((TotalMet > 0) || (TotalCri > 0) || (TotalDeut > 0)) {
+								telegramMessenger.SendMessage($"Resources sent!:\n{TotalMet} Metal\n{TotalCri} Crystal\n{TotalDeut} Deuterium");
+							} else {
+								telegramMessenger.SendMessage("No resources sent");
+							}
 						}
 					} else {
 						Helpers.WriteLog(LogType.Warning, LogSender.Brain, "Skipping autorepatriate: unable to parse custom destination");

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -1193,7 +1193,9 @@ namespace Tbot {
 			FleetPrediction fleetPrediction = Helpers.CalcFleetPrediction(celestial.Coordinate, destination, celestial.Ships, Missions.Deploy, speed, researches, serverData, userInfo.Class);
 			int fleetId = SendFleet(celestial, celestial.Ships, destination, Missions.Deploy, speed, payload, userInfo.Class, true);
 
-			if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
+			if (fleetId != (int) SendFleetCode.GenericError ||
+				fleetId != (int) SendFleetCode.AfterSleepTime ||
+				fleetId != (int) SendFleetCode.NotEnoughSlots) {
 				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleet {fleetId} deployed from {celestial.Coordinate.Type} to {destination.Type}\nPredicted time: {TimeSpan.FromSeconds(fleetPrediction.Time).ToString()}");
 				telegramMessenger.SendMessage($"Fleet {fleetId} switched from {celestial.Coordinate.Type} to {destination.Type}\nPredicted time: {TimeSpan.FromSeconds(fleetPrediction.Time).ToString()}");
 				return;
@@ -1252,7 +1254,9 @@ namespace Tbot {
 			FleetPrediction fleetPrediction = Helpers.CalcFleetPrediction(celestial.Coordinate, dest, celestial.Ships, Missions.Deploy, speed, researches, serverData, userInfo.Class);
 			int fleetId = SendFleet(celestial, celestial.Ships, dest, Missions.Deploy, speed, payload, userInfo.Class, true);
 
-			if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
+			if (fleetId != (int) SendFleetCode.GenericError ||
+				fleetId != (int) SendFleetCode.AfterSleepTime ||
+				fleetId != (int) SendFleetCode.NotEnoughSlots) {
 				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Fleet {fleetId} switched from {celestial.Coordinate.Type} to {dest.Type}\nPredicted time: {TimeSpan.FromSeconds(fleetPrediction.Time).ToString()}");
 				if ((bool) settings.TelegramMessenger.Active || fromTelegram)
 					telegramMessenger.SendMessage($"Fleet {fleetId} switched from {celestial.Coordinate.Type} to {dest.Type}\nPredicted time: {TimeSpan.FromSeconds(fleetPrediction.Time).ToString()}");
@@ -1377,7 +1381,9 @@ namespace Tbot {
 
 			int fleetId = SendFleet(fromCelestial, attackingShips, target, Missions.Attack, speed);
 
-			if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
+			if (fleetId != (int) SendFleetCode.GenericError ||
+				fleetId != (int) SendFleetCode.AfterSleepTime ||
+				fleetId != (int) SendFleetCode.NotEnoughSlots) {
 				Helpers.WriteLog(LogType.Info, LogSender.FleetScheduler, $"EspionageProbe sent to crash on {target.ToString()}");
 
 				telegramMessenger.SendMessage($"EspionageProbe sent to crash on {target.ToString()}");
@@ -1481,7 +1487,7 @@ namespace Tbot {
 				payload.Deuterium = 0;
 
 			FleetHypotesis possibleFleet = new();
-			int fleetId = 0;
+			int fleetId = (int) SendFleetCode.GenericError;
 			bool AlreadySent = false; //permit to swith to Harvest mission if not enough fuel to Deploy if celestial far away
 
 			//Doing DefaultMission or telegram /ghostto mission
@@ -1501,7 +1507,9 @@ namespace Tbot {
 					if (CheckFuel(fleet, celestial)) {
 						fleetId = SendFleet(fleet.Origin, fleet.Ships, fleet.Destination, fleet.Mission, fleet.Speed, payload, userInfo.Class, true);
 
-						if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
+						if (fleetId != (int) SendFleetCode.GenericError ||
+							fleetId != (int) SendFleetCode.AfterSleepTime ||
+							fleetId != (int) SendFleetCode.NotEnoughSlots) {
 							possibleFleet = fleet;
 							AlreadySent = true;
 							break;
@@ -1531,7 +1539,9 @@ namespace Tbot {
 						if (CheckFuel(fleet, celestial)) {
 							fleetId = SendFleet(fleet.Origin, fleet.Ships, fleet.Destination, fleet.Mission, fleet.Speed, payload, userInfo.Class, true);
 
-							if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
+							if (fleetId != (int) SendFleetCode.GenericError ||
+								fleetId != (int) SendFleetCode.AfterSleepTime ||
+								fleetId != (int) SendFleetCode.NotEnoughSlots) {
 								possibleFleet = fleet;
 								AlreadySent = true;
 								break;
@@ -1551,7 +1561,9 @@ namespace Tbot {
 						if (CheckFuel(fleet, celestial)) {
 							fleetId = SendFleet(fleet.Origin, fleet.Ships, fleet.Destination, fleet.Mission, fleet.Speed, payload, userInfo.Class, true);
 
-							if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
+							if (fleetId != (int) SendFleetCode.GenericError ||
+								fleetId != (int) SendFleetCode.AfterSleepTime ||
+								fleetId != (int) SendFleetCode.NotEnoughSlots) {
 								possibleFleet = fleet;
 								AlreadySent = true;
 								break;
@@ -1571,7 +1583,9 @@ namespace Tbot {
 						if (CheckFuel(fleet, celestial)) {
 							fleetId = SendFleet(fleet.Origin, fleet.Ships, fleet.Destination, fleet.Mission, fleet.Speed, payload, userInfo.Class, true);
 
-							if (fleetId != 0 || fleetId != -1 || fleetId != -2) {
+							if (fleetId != (int) SendFleetCode.GenericError ||
+								fleetId != (int) SendFleetCode.AfterSleepTime ||
+								fleetId != (int) SendFleetCode.NotEnoughSlots) {
 								possibleFleet = fleet;
 								AlreadySent = true;
 								break;
@@ -1602,7 +1616,9 @@ namespace Tbot {
 
 			
 			if ((bool) settings.SleepMode.AutoFleetSave.Recall && AlreadySent) {
-				if (fleetId != 0 && fleetId != -1 && fleetId != -2) {
+				if (fleetId != (int) SendFleetCode.GenericError ||
+					fleetId != (int) SendFleetCode.AfterSleepTime ||
+					fleetId != (int) SendFleetCode.NotEnoughSlots) {
 					Fleet fleet = fleets.Single(fleet => fleet.ID == fleetId);
 					DateTime time = GetDateTime();
 					var interval = ((minDuration / 2) * 1000) + Helpers.CalcRandomInterval(IntervalType.AMinuteOrTwo);
@@ -1616,7 +1632,9 @@ namespace Tbot {
 				}
 			}
 			else {
-				if (fleetId != 0 && fleetId != -1 && fleetId != -2) {
+				if (fleetId != (int) SendFleetCode.GenericError ||
+					fleetId != (int) SendFleetCode.AfterSleepTime ||
+					fleetId != (int) SendFleetCode.NotEnoughSlots) {
 					Fleet fleet = fleets.Single(fleet => fleet.ID == fleetId);
 					Helpers.WriteLog(LogType.Info, LogSender.FleetScheduler, $"Fleet {fleetId} send to {possibleFleet.Mission} on {possibleFleet.Destination.ToString()}, arrive at {possibleFleet.Duration} fuel consumed: {possibleFleet.Fuel.ToString("#,#", CultureInfo.InvariantCulture)}");
 					if ((bool) settings.TelegramMessenger.Active || fromTelegram)
@@ -2219,7 +2237,7 @@ namespace Tbot {
 		}
 
 		private static void AutoResearch(object state) {
-			int fleetId = 0;
+			int fleetId = (int) SendFleetCode.GenericError;
 			bool stop = false;
 			bool delay = false;
 			try {
@@ -2371,10 +2389,10 @@ namespace Tbot {
 										.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) settings.Brain.AutoResearch.Transports.Origin.Type))
 										.SingleOrDefault() ?? new() { ID = 0 };
 									fleetId = HandleMinerTransport(origin, celestial, cost);
-									if (fleetId == -1) {
+									if (fleetId == (int)SendFleetCode.AfterSleepTime) {
 										stop = true;
 									}
-									if (fleetId == -2) {
+									if (fleetId == (int)SendFleetCode.NotEnoughSlots) {
 										delay = true;
 									}
 								} else {
@@ -2437,7 +2455,7 @@ namespace Tbot {
 							var incomingFleets = Helpers.GetIncomingFleets(celestial, fleets);
 							if (celestial.Constructions.ResearchCountdown != 0)
 								interval = (long) ((long) celestial.Constructions.ResearchCountdown * (long) 1000) + (long) Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
-							else if (fleetId > 0) {
+							else if (fleetId > (int)SendFleetCode.GenericError) {
 								var fleet = fleets.Single(f => f.ID == fleetId && f.Mission == Missions.Transport);
 								interval = (fleet.ArriveIn * 1000) + Helpers.CalcRandomInterval(IntervalType.SomeSeconds);
 							} else if (celestial.Constructions.BuildingID == (int) Buildables.ResearchLab)
@@ -2721,7 +2739,7 @@ namespace Tbot {
 
 												slots = UpdateSlots();
 												var fleetId = SendFleet(closest, ships, target.Celestial.Coordinate, Missions.Spy, Speeds.HundredPercent);
-												if (fleetId > 0) {
+												if (fleetId > (int)SendFleetCode.GenericError) {
 													freeSlots--;
 													numProbed++;
 													celestialProbes[closest.ID] -= neededProbes;
@@ -2734,7 +2752,7 @@ namespace Tbot {
 													farmTargets.Add(target);
 
 													break;
-												} else if (fleetId == -1) {
+												} else if (fleetId == (int)SendFleetCode.AfterSleepTime) {
 													stop = true;
 													return;
 												}
@@ -3038,10 +3056,10 @@ namespace Tbot {
 
 								var fleetId = SendFleet(fromCelestial, attackingShips, target.Celestial.Coordinate, Missions.Attack, speed);
 
-								if (fleetId > 0) {
+								if (fleetId > (int)SendFleetCode.GenericError) {
 									freeSlots--;
 								}
-								else if (fleetId == -1) {
+								else if (fleetId == (int)SendFleetCode.AfterSleepTime) {
 									stop = true;
 									return;
 								}
@@ -3255,7 +3273,7 @@ namespace Tbot {
 		}
 
 		private static void AutoMineCelestial(Celestial celestial, Buildings maxBuildings, Facilities maxFacilities, Facilities maxLunarFacilities, AutoMinerSettings autoMinerSettings) {
-			int fleetId = 0;
+			int fleetId = (int) SendFleetCode.GenericError;
 			Buildables buildable = Buildables.Null;
 			int level = 0;
 			bool started = false;
@@ -3428,11 +3446,11 @@ namespace Tbot {
 										.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) settings.Brain.AutoMine.Transports.Origin.Type))
 										.SingleOrDefault() ?? new() { ID = 0 };
 								fleetId = HandleMinerTransport(origin, celestial, xCostBuildable);
-								if (fleetId == -1) {
+								if (fleetId == (int) SendFleetCode.AfterSleepTime) {
 									stop = true;
 									return;
 								}
-								if (fleetId == -2) {
+								if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
 									delay = true;
 									return;
 								}
@@ -3979,11 +3997,11 @@ namespace Tbot {
 
 								if (payload.TotalResources > 0) {
 									var fleetId = SendFleet(tempCelestial, ships, destinationCoordinate, Missions.Transport, Speeds.HundredPercent, payload);
-									if (fleetId == -1) {
+									if (fleetId == (int) SendFleetCode.AfterSleepTime) {
 										stop = true;
 										return;
 									}
-									if (fleetId == -2) {
+									if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
 										delay = true;
 										return;
 									}
@@ -4205,8 +4223,8 @@ namespace Tbot {
 
 		public static void TelegramRetireFleet(int fleetId) {
 			fleets = UpdateFleets();
-			Fleet ToRecallFleet = fleets.SingleOrDefault(f => f.ID == fleetId) ?? new() { ID = 0 };
-			if ( ToRecallFleet.ID == 0) {
+			Fleet ToRecallFleet = fleets.SingleOrDefault(f => f.ID == fleetId) ?? new() { ID = (int) SendFleetCode.GenericError };
+			if ( ToRecallFleet.ID == (int) SendFleetCode.GenericError) {
 				telegramMessenger.SendMessage($"<code>[{userInfo.PlayerName}@{serverData.Name}]</code> Unable to recall fleet! Already recalled?");
 				return;
 			}
@@ -4571,11 +4589,11 @@ namespace Tbot {
 											}
 											if (slots.ExpFree > 0) {
 												var fleetId = SendFleet(origin, fleet, destination, Missions.Expedition, Speeds.HundredPercent, payload);
-												if (fleetId == -1) {
+												if (fleetId == (int) SendFleetCode.AfterSleepTime) {
 													stop = true;
 													return;
 												}
-												if (fleetId == -2) {
+												if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
 													delay = true;
 													return;
 												}
@@ -4765,7 +4783,7 @@ namespace Tbot {
 						Helpers.WriteLog(LogType.Info, LogSender.Harvest, "Skipping harvest: there are no fields to harvest.");
 
 					foreach (Coordinate destination in dic.Keys) {
-						var fleetId = 0;
+						var fleetId = (int) SendFleetCode.GenericError;
 						Celestial origin = dic[destination];
 						if (destination.Position == 16) {
 							ExpeditionDebris debris = ogamedService.GetGalaxyInfo(destination).ExpeditionDebris;
@@ -4780,11 +4798,11 @@ namespace Tbot {
 								fleetId = SendFleet(origin, new Ships { Recycler = recyclersToSend }, destination, Missions.Harvest, Speeds.HundredPercent);
 							}
 						}
-						if (fleetId == -1) {
+						if (fleetId == (int) SendFleetCode.AfterSleepTime) {
 							stop = true;
 							return;
 						}
-						if (fleetId == -2) {
+						if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
 							delay = true;
 							return;
 						}
@@ -4911,11 +4929,11 @@ namespace Tbot {
 									foreach (var target in filteredTargets) {
 										Ships ships = new() { ColonyShip = 1 };
 										var fleetId = SendFleet(origin, ships, target, Missions.Colonize, Speeds.HundredPercent);
-										if (fleetId == -1) {
+										if (fleetId == (int) SendFleetCode.AfterSleepTime) {
 											stop = true;
 											return;
 										}
-										if (fleetId == -2) {
+										if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
 											delay = true;
 											return;
 										}

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -204,20 +204,23 @@ namespace Tbot {
 					xaSem[Feature.TelegramAutoPing] = new Semaphore(1, 1);
 
 					features = new();
-					features.AddOrUpdate(Feature.Defender, false, HandleStartStopFeatures);
-					features.AddOrUpdate(Feature.Brain, false, HandleStartStopFeatures);
-					features.AddOrUpdate(Feature.BrainAutobuildCargo, false, HandleStartStopFeatures);
-					features.AddOrUpdate(Feature.BrainAutoRepatriate, false, HandleStartStopFeatures);
-					features.AddOrUpdate(Feature.BrainAutoMine, false, HandleStartStopFeatures);
-					features.AddOrUpdate(Feature.BrainOfferOfTheDay, false, HandleStartStopFeatures);
-					features.AddOrUpdate(Feature.BrainAutoResearch, false, HandleStartStopFeatures);
-					features.AddOrUpdate(Feature.AutoFarm, false, HandleStartStopFeatures);
-					features.AddOrUpdate(Feature.Expeditions, false, HandleStartStopFeatures);
-					features.AddOrUpdate(Feature.Colonize, false, HandleStartStopFeatures);
-					features.AddOrUpdate(Feature.Harvest, false, HandleStartStopFeatures);
-					features.AddOrUpdate(Feature.FleetScheduler, false, HandleStartStopFeatures);
-					features.AddOrUpdate(Feature.SleepMode, false, HandleStartStopFeatures);
-					features.AddOrUpdate(Feature.TelegramAutoPing, false, HandleStartStopFeatures);
+					InitializeFeatures(new List<Feature>() {
+						Feature.Defender,
+						Feature.Brain,
+						Feature.BrainAutobuildCargo,
+						Feature.BrainAutoRepatriate,
+						Feature.BrainAutoMine,
+						Feature.BrainOfferOfTheDay,
+						Feature.BrainAutoResearch,
+						Feature.AutoFarm,
+						Feature.Expeditions,
+						Feature.Colonize, 
+						Feature.Harvest,
+						Feature.FleetScheduler,
+						Feature.SleepMode,
+						Feature.TelegramAutoPing
+					});
+					
 
 					Helpers.WriteLog(LogType.Info, LogSender.Tbot, "Initializing data...");
 					celestials = GetPlanets();
@@ -449,20 +452,26 @@ namespace Tbot {
 			}
 		}
 
-		public static void InitializeFeatures() {
-			//features.AddOrUpdate(Feature.SleepMode, false, HandleStartStopFeatures);
-			features.AddOrUpdate(Feature.Defender, false, HandleStartStopFeatures);
-			features.AddOrUpdate(Feature.Brain, false, HandleStartStopFeatures);
-			features.AddOrUpdate(Feature.BrainAutobuildCargo, false, HandleStartStopFeatures);
-			features.AddOrUpdate(Feature.BrainAutoRepatriate, false, HandleStartStopFeatures);
-			features.AddOrUpdate(Feature.BrainAutoMine, false, HandleStartStopFeatures);
-			features.AddOrUpdate(Feature.BrainOfferOfTheDay, false, HandleStartStopFeatures);
-			features.AddOrUpdate(Feature.BrainAutoResearch, false, HandleStartStopFeatures);
-			features.AddOrUpdate(Feature.AutoFarm, false, HandleStartStopFeatures);
-			features.AddOrUpdate(Feature.Expeditions, false, HandleStartStopFeatures);
-			features.AddOrUpdate(Feature.Harvest, false, HandleStartStopFeatures);
-			features.AddOrUpdate(Feature.Colonize, false, HandleStartStopFeatures);
-			features.AddOrUpdate(Feature.TelegramAutoPing, false, HandleStartStopFeatures);
+		public static void InitializeFeatures(List<Feature> featuresToInitialize = null) {
+			if(featuresToInitialize == null) {
+				featuresToInitialize = new List<Feature>() {
+					Feature.Defender,
+					Feature.Brain,
+					Feature.BrainAutobuildCargo,
+					Feature.BrainAutoRepatriate,
+					Feature.BrainAutoMine,
+					Feature.BrainOfferOfTheDay,
+					Feature.BrainAutoResearch,
+					Feature.AutoFarm,
+					Feature.Expeditions,
+					Feature.Harvest,
+					Feature.Colonize,
+					Feature.TelegramAutoPing
+				};
+			}
+			foreach(Feature feat in featuresToInitialize) {
+				features.AddOrUpdate(feat, false, HandleStartStopFeatures);
+			}
 		}
 
 		private static void ReadSettings() {

--- a/TBot/Program.cs
+++ b/TBot/Program.cs
@@ -4076,15 +4076,15 @@ namespace Tbot {
 
 			if (!ships.HasMovableFleet()) {
 				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, "Unable to send fleet: there are no ships to send");
-				return 0;
+				return (int)SendFleetCode.GenericError;
 			}
 			if (origin.Coordinate.IsSame(destination)) {
 				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, "Unable to send fleet: origin and destination are the same");
-				return 0;
+				return (int) SendFleetCode.GenericError;
 			}
 			if (destination.Galaxy <= 0 || destination.Galaxy > serverData.Galaxies || destination.System <= 0 || destination.System > 500 || destination.Position <= 0 || destination.Position > 17) {
 				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, "Unable to send fleet: invalid destination");
-				return 0;
+				return (int) SendFleetCode.GenericError;
 			}
 
 			/*
@@ -4105,7 +4105,7 @@ namespace Tbot {
 
 			if (!Helpers.GetValidSpeedsForClass(playerClass).Any(s => s == speed)) {
 				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, "Unable to send fleet: speed not available for your class");
-				return 0;
+				return (int) SendFleetCode.GenericError;
 			}			
 			FleetPrediction fleetPrediction = Helpers.CalcFleetPrediction(origin.Coordinate, destination, ships, mission, speed, researches, serverData, userInfo.Class);
 			Helpers.WriteLog(LogType.Debug, LogSender.FleetScheduler, $"Calculated flight time (one-way): {TimeSpan.FromSeconds(fleetPrediction.Time).ToString()}");
@@ -4121,13 +4121,13 @@ namespace Tbot {
 			origin = UpdatePlanet(origin, UpdateTypes.Resources);
 			if (origin.Resources.Deuterium < fleetPrediction.Fuel) {
 				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, "Unable to send fleet: not enough deuterium!");
-				return 0;
+				return (int) SendFleetCode.GenericError;
 			}
 
 			// TODO: Fix ugly workaround.
 			if (Helpers.CalcFleetFuelCapacity(ships, serverData.ProbeCargo) != 0 && Helpers.CalcFleetFuelCapacity(ships, serverData.ProbeCargo) < fleetPrediction.Fuel) {
 				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, "Unable to send fleet: ships don't have enough fuel capacity!");
-				return 0;
+				return (int) SendFleetCode.GenericError;
 			}
 
 			if (
@@ -4140,7 +4140,7 @@ namespace Tbot {
 
 				if (Helpers.ShouldSleep(time, goToSleep, wakeUp)) {
 					Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, "Unable to send fleet: bed time has passed");
-					return -1;
+					return (int) SendFleetCode.AfterSleepTime;
 				}
 
 				if (goToSleep >= wakeUp) {
@@ -4160,7 +4160,7 @@ namespace Tbot {
 
 				if (returnTime >= goToSleep && returnTime <= wakeUp) {
 					Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, "Unable to send fleet: it would come back during sleep time");
-					return -1;
+					return (int) SendFleetCode.AfterSleepTime;
 				}
 			}
 			slots = UpdateSlots();
@@ -4177,11 +4177,11 @@ namespace Tbot {
 				} catch (Exception e) {
 					Helpers.WriteLog(LogType.Error, LogSender.FleetScheduler, $"Unable to send fleet: an exception has occurred: {e.Message}");
 					Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, $"Stacktrace: {e.StackTrace}");
-					return 0;
+					return (int) SendFleetCode.GenericError;
 				}
 			} else {
 				Helpers.WriteLog(LogType.Warning, LogSender.FleetScheduler, "Unable to send fleet, no slots available");
-				return -2;
+				return (int) SendFleetCode.NotEnoughSlots;
 			}
 		}
 


### PR DESCRIPTION
Added a few improvements:
- SendFleetCode enum to improve code readability (no magic numbers comparison)
    - NotEnoughSlots or AfterSleepTime return value added as integer enums
- Parse duration string (format XXhYYmZZs )
    - Any time field can be missing, meaning that also XXh or XXhZZs still work
- Let TBot execute and kill its Ogamed process rather than all ogamed instances found in the running environment
    - Previous implementation was killing all processes named after ogamed rather than its own