### PR TITLE
check Moon's Resources before Brain.Transports.Origin

### DIFF
--- a/TBot.Ogame.Infrastructure/Enums/SendFleetCode.cs
+++ b/TBot.Ogame.Infrastructure/Enums/SendFleetCode.cs
@@ -9,6 +9,7 @@ namespace TBot.Ogame.Infrastructure.Enums {
 		GenericError = 0,
 		AfterSleepTime = -1,
 		NotEnoughSlots = -2,
-		QuickerToWaitForProduction = -3
+		QuickerToWaitForProduction = -3,
+		NotEnoughRessources = -4		
 	}
 }

--- a/TBot/Includes/CalculationService.cs
+++ b/TBot/Includes/CalculationService.cs
@@ -4806,5 +4806,16 @@ namespace Tbot.Includes {
 				.Where(planet => (planet as Planet).Temperature.Max >= minTemperature && (planet as Planet).Temperature.Max <= maxTemperature)
 				.Count();
 		}
+
+		public bool	IsThereMoonHere(List<Celestial> planets, Celestial celestial) {
+			Celestial moon = planets.Unique()
+				.Where(c => c.Coordinate.Galaxy == (int) celestial.Coordinate.Galaxy)
+				.Where(c => c.Coordinate.System == (int) celestial.Coordinate.System)
+				.Where(c => c.Coordinate.Position == (int) celestial.Coordinate.Position)
+				.Where(c => c.Coordinate.Type == Celestials.Moon)
+				.SingleOrDefault() ?? new() { ID = 0 };
+
+			return moon.ID == 0 ? false: true;
+		}
 	}
 }

--- a/TBot/Includes/ICalculationService.cs
+++ b/TBot/Includes/ICalculationService.cs
@@ -152,6 +152,7 @@ namespace Tbot.Includes {
 		bool ShouldAbandon(Planet celestial, int maxCases, int Temperature, Fields fieldsSettings, Temperature temperaturesSettings);
 		int CountPlanetsInRange(List<Planet> planets, int galaxy, int minSystem, int maxSystem, int minPosition, int maxPositions, int minSlots, int minTemperature, int maxTemperature);
 		int CountPlanetsInRange(List<Celestial> planets, int galaxy, int minSystem, int maxSystem, int minPosition, int maxPositions, int minSlots, int minTemperature, int maxTemperature);
+		bool IsThereMoonHere(List<Celestial> planets, Celestial celestial);
 
 	}
 

--- a/TBot/Workers/Brain/AutoResearchWorker.cs
+++ b/TBot/Workers/Brain/AutoResearchWorker.cs
@@ -173,14 +173,36 @@ namespace Tbot.Workers.Brain {
 						if ((bool) _tbotInstance.InstanceSettings.Brain.AutoResearch.Transports.Active && (bool) _tbotInstance.InstanceSettings.Brain.Transports.Active) {
 							_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();
 							if (!_calculationService.IsThereTransportTowardsCelestial(celestial, _tbotInstance.UserData.fleets)) {
-								Celestial origin = _tbotInstance.UserData.celestials
-									.Unique()
-									.Where(c => c.Coordinate.Galaxy == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Galaxy)
-									.Where(c => c.Coordinate.System == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.System)
-									.Where(c => c.Coordinate.Position == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Position)
-									.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Type))
-									.SingleOrDefault() ?? new() { ID = 0 };
+								Celestial origin;
+								if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.CheckMoonOrPlanetFirst && _calculationService.IsThereMoonHere(_tbotInstance.UserData.celestials, celestial)) {
+									origin = _tbotInstance.UserData.celestials
+											.Unique()
+											.Where(c => c.Coordinate.Galaxy == (int) celestial.Coordinate.Galaxy)
+											.Where(c => c.Coordinate.System == (int) celestial.Coordinate.System)
+											.Where(c => c.Coordinate.Position == (int) celestial.Coordinate.Position)
+											.Where(c => c.Coordinate.Type == (celestial.Coordinate.Type == Celestials.Planet ? Celestials.Moon : Celestials.Planet))
+											.SingleOrDefault() ?? new() { ID = 0 };
+								} else {
+									origin = _tbotInstance.UserData.celestials
+											.Unique()
+											.Where(c => c.Coordinate.Galaxy == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Galaxy)
+											.Where(c => c.Coordinate.System == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.System)
+											.Where(c => c.Coordinate.Position == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Position)
+											.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Type))
+											.SingleOrDefault() ?? new() { ID = 0 };
+								}
 								fleetId = await _fleetScheduler.HandleMinerTransport(origin, celestial, cost, Buildables.Null);
+
+								if (fleetId == (int) SendFleetCode.NotEnoughRessources) {
+									origin = _tbotInstance.UserData.celestials
+										.Unique()
+										.Where(c => c.Coordinate.Galaxy == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Galaxy)
+										.Where(c => c.Coordinate.System == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.System)
+										.Where(c => c.Coordinate.Position == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Position)
+										.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Type))
+										.SingleOrDefault() ?? new() { ID = 0 };
+									fleetId = await _fleetScheduler.HandleMinerTransport(origin, celestial, cost, Buildables.Null);
+								}
 								if (fleetId == (int) SendFleetCode.AfterSleepTime) {
 									stop = true;
 								}

--- a/TBot/Workers/Brain/LifeformsAutoMineCelestialWorker.cs
+++ b/TBot/Workers/Brain/LifeformsAutoMineCelestialWorker.cs
@@ -182,14 +182,37 @@ namespace Tbot.Workers.Brain {
 								if ((bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoMine.Transports.Active && (bool) _tbotInstance.InstanceSettings.Brain.Transports.Active) {
 									_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();
 									if (!_calculationService.IsThereTransportTowardsCelestial(celestial, _tbotInstance.UserData.fleets)) {
-										Celestial origin = _tbotInstance.UserData.celestials
+										Celestial origin;
+										if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.CheckMoonOrPlanetFirst && _calculationService.IsThereMoonHere(_tbotInstance.UserData.celestials, celestial)) {
+											origin = _tbotInstance.UserData.celestials
+													.Unique()
+													.Where(c => c.Coordinate.Galaxy == (int) celestial.Coordinate.Galaxy)
+													.Where(c => c.Coordinate.System == (int) celestial.Coordinate.System)
+													.Where(c => c.Coordinate.Position == (int) celestial.Coordinate.Position)
+													.Where(c => c.Coordinate.Type == (celestial.Coordinate.Type == Celestials.Planet ? Celestials.Moon : Celestials.Planet))
+													.SingleOrDefault() ?? new() { ID = 0 };
+										} else {
+											origin = _tbotInstance.UserData.celestials
+													.Unique()
+													.Where(c => c.Coordinate.Galaxy == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Galaxy)
+													.Where(c => c.Coordinate.System == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.System)
+													.Where(c => c.Coordinate.Position == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Position)
+													.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Type))
+													.SingleOrDefault() ?? new() { ID = 0 };
+										}
+										fleetId = await _fleetScheduler.HandleMinerTransport(origin, celestial, xCostBuildable, buildable, maxLFBuildings, preventIfMoreExpensiveThanNextMine);
+										
+										if (fleetId == (int) SendFleetCode.NotEnoughRessources) {
+											origin = _tbotInstance.UserData.celestials
 												.Unique()
 												.Where(c => c.Coordinate.Galaxy == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Galaxy)
 												.Where(c => c.Coordinate.System == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.System)
 												.Where(c => c.Coordinate.Position == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Position)
 												.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Type))
-												.SingleOrDefault() ?? new() { ID = 0 };
-										fleetId = await _fleetScheduler.HandleMinerTransport(origin, celestial, xCostBuildable, buildable, maxLFBuildings, preventIfMoreExpensiveThanNextMine);
+												.SingleOrDefault() ?? new() { ID = 0 };								
+											fleetId = await _fleetScheduler.HandleMinerTransport(origin, celestial, xCostBuildable, buildable, maxLFBuildings, preventIfMoreExpensiveThanNextMine);
+										}
+										
 										if (fleetId == (int) SendFleetCode.AfterSleepTime) {
 											stop = true;
 											return;

--- a/TBot/Workers/Brain/LifeformsAutoResearchCelestialWorker.cs
+++ b/TBot/Workers/Brain/LifeformsAutoResearchCelestialWorker.cs
@@ -182,14 +182,36 @@ namespace Tbot.Workers.Brain {
 							if ((bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.Transports.Active && (bool) _tbotInstance.InstanceSettings.Brain.Transports.Active) {
 								_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();
 								if (!_calculationService.IsThereTransportTowardsCelestial(celestial, _tbotInstance.UserData.fleets)) {
-									Celestial origin = _tbotInstance.UserData.celestials
+									Celestial origin;
+									if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.CheckMoonOrPlanetFirst && _calculationService.IsThereMoonHere(_tbotInstance.UserData.celestials, celestial)) {
+										origin = _tbotInstance.UserData.celestials
+												.Unique()
+												.Where(c => c.Coordinate.Galaxy == (int) celestial.Coordinate.Galaxy)
+												.Where(c => c.Coordinate.System == (int) celestial.Coordinate.System)
+												.Where(c => c.Coordinate.Position == (int) celestial.Coordinate.Position)
+												.Where(c => c.Coordinate.Type == (celestial.Coordinate.Type == Celestials.Planet ? Celestials.Moon : Celestials.Planet))
+												.SingleOrDefault() ?? new() { ID = 0 };
+									} else {
+										origin = _tbotInstance.UserData.celestials
+												.Unique()
+												.Where(c => c.Coordinate.Galaxy == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Galaxy)
+												.Where(c => c.Coordinate.System == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.System)
+												.Where(c => c.Coordinate.Position == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Position)
+												.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Type))
+												.SingleOrDefault() ?? new() { ID = 0 };
+									}
+									fleetId = await _fleetScheduler.HandleMinerTransport(origin, celestial, xCostBuildable, Buildables.Null);
+									
+									if (fleetId == (int) SendFleetCode.NotEnoughRessources) {
+										origin = _tbotInstance.UserData.celestials
 											.Unique()
 											.Where(c => c.Coordinate.Galaxy == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Galaxy)
 											.Where(c => c.Coordinate.System == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.System)
 											.Where(c => c.Coordinate.Position == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Position)
 											.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Type))
-											.SingleOrDefault() ?? new() { ID = 0 };
-									fleetId = await _fleetScheduler.HandleMinerTransport(origin, celestial, xCostBuildable, Buildables.Null);
+											.SingleOrDefault() ?? new() { ID = 0 };	
+										fleetId = await _fleetScheduler.HandleMinerTransport(origin, celestial, xCostBuildable, Buildables.Null);
+									}
 									if (fleetId == (int) SendFleetCode.AfterSleepTime) {
 										stop = true;
 										return;

--- a/TBot/Workers/FleetScheduler.cs
+++ b/TBot/Workers/FleetScheduler.cs
@@ -878,7 +878,7 @@ namespace Tbot.Workers {
 						}
 					} else {
 						_tbotInstance.log(LogLevel.Information, LogSender.FleetScheduler, $"Skipping transport: not enough resources in origin. Needed: {missingResources.TransportableResources} - Available: {origin.Resources.TransportableResources}");
-						return 0;
+						return (int) SendFleetCode.NotEnoughRessources;
 					}
 				}
 			} catch (Exception e) {
@@ -1017,7 +1017,7 @@ namespace Tbot.Workers {
 						}
 					} else {
 						_tbotInstance.log(LogLevel.Information, LogSender.FleetScheduler, $"Skipping transport: not enough resources in origin. Needed: {missingResources.TransportableResources} - Available: {origin.Resources.TransportableResources}");
-						return 0;
+						return (int) SendFleetCode.NotEnoughRessources;
 					}
 				}
 			} catch (Exception e) {
@@ -1129,11 +1129,11 @@ namespace Tbot.Workers {
 					long TotalCri = 0;
 					long TotalDeut = 0;
 					Coordinate destinationCoordinate = new(
-					(int) _tbotInstance.InstanceSettings.Brain.AutoRepatriate.Target.Galaxy,
-						(int) _tbotInstance.InstanceSettings.Brain.AutoRepatriate.Target.System,
-						(int) _tbotInstance.InstanceSettings.Brain.AutoRepatriate.Target.Position,
-						Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.AutoRepatriate.Target.Type)
-					);
+						(int) _tbotInstance.InstanceSettings.Brain.AutoRepatriate.Target.Galaxy,
+							(int) _tbotInstance.InstanceSettings.Brain.AutoRepatriate.Target.System,
+							(int) _tbotInstance.InstanceSettings.Brain.AutoRepatriate.Target.Position,
+							Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.AutoRepatriate.Target.Type)
+						);
 					List<Celestial> newCelestials = _tbotInstance.UserData.celestials.ToList();
 					List<Celestial> celestialsToExclude = _calcService.ParseCelestialsList(_tbotInstance.InstanceSettings.Brain.AutoRepatriate.Exclude, _tbotInstance.UserData.celestials);
 

--- a/TBot/instance_settings.json
+++ b/TBot/instance_settings.json
@@ -117,7 +117,8 @@
 				"System": 333,
 				"Position": 8,
 				"Type": "Moon"
-			}
+			},
+			"CheckMoonOrPlanetFirst": true
 		},
 		"AutoMine": {
 			"Active": true,


### PR DESCRIPTION
Start checking the moon/planet's resources before Brain.Transports.Origin to avoid long transports

Can be upgraded using Moon/Planet's resources and the adding Brain.Transports.Origin resources