### PR TITLE
Fix AutoMine skipping new homeworlds and quote device-lang

### DIFF
--- a/TBot.Ogame.Infrastructure/OgameService.cs
+++ b/TBot.Ogame.Infrastructure/OgameService.cs
@@ -156,7 +156,7 @@ namespace TBot.Ogame.Infrastructure {
 					args += $" --device-timezone={device.Timezone}";
 				}
 				if (device.Lang != "") {
-					args += $" --device-lang={device.Lang}";
+					args += $" --device-lang=\"{device.Lang}\"";
 				}
 
 				ogameProc = new Process();

--- a/TBot/Workers/Brain/AutoMineWorker.cs
+++ b/TBot/Workers/Brain/AutoMineWorker.cs
@@ -119,7 +119,7 @@ namespace Tbot.Workers.Brain {
 							_tbotInstance.UserData.nextDOIR = DOIR;
 						}
 					}
-					if (celestial.Coordinate.Type == Celestials.Planet && celestial.Fields.Built == 0 && (bool) _tbotInstance.InstanceSettings.AutoColonize.Abandon.Active) {
+					if (_tbotInstance.UserData.celestials.Count > 1 && celestial.Coordinate.Type == Celestials.Planet && celestial.Fields.Built == 0 && (bool) _tbotInstance.InstanceSettings.AutoColonize.Abandon.Active) {
 						if (_calculationService.ShouldAbandon(celestial as Planet, celestial.Fields.Total, abaCelestial.Temperature.Max, fieldsSettings, temperaturesSettings)) {
 							DoLog(LogLevel.Debug, $"Skipping {celestial.ToString()}: planet should be abandoned.");
 						} else {


### PR DESCRIPTION
## Summary
- AutoMine no longer treats a 0-building home planet as abandon-eligible when Abandon is on and it is the only celestial. Matches the existing `celestials.Count > 1` guard in `AutoMineCelestialWorker`.
- Quote `--device-lang` the same way as `--device-user-agent`, so values with commas are passed as one ogamed flag.

## Test plan
- [ ] New account, one empty planet, `AutoColonize.Abandon.Active: true`: AutoMine still queues the first mine
- [ ] Multiple planets with Abandon on: empty colonies that fail the abandon filters are still skipped
- [ ] Device lang such as `fr` (and a quoted multi-tag value) starts ogamed without a language parse panic